### PR TITLE
move scripts/magic_folder_cli to magic_folder/cli

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -32,7 +32,7 @@ from twisted.internet.error import (
     ProcessTerminated,
 )
 
-from magic_folder.scripts.magic_folder_cli import (
+from magic_folder.cli import (
     MagicFolderCommand,
     do_magic_folder,
 )

--- a/integration/test_magic_folder.py
+++ b/integration/test_magic_folder.py
@@ -27,7 +27,7 @@ from twisted.web.client import (
 from magic_folder.frontends.magic_folder import (
     load_magic_folders,
 )
-from magic_folder.scripts.magic_folder_cli import (
+from magic_folder.cli import (
     MagicFolderCommand,
     do_magic_folder,
     poll,
@@ -342,7 +342,7 @@ def test_edmond_uploads_then_restarts(reactor, request, temp_dir, introducer_fur
 
     # let it upload; poll the HTTP magic-folder status API until it is
     # uploaded
-    from magic_folder.scripts.magic_folder_cli import _get_json_for_fragment
+    from magic_folder.cli import _get_json_for_fragment
 
     with open(join(edmond.node_directory, u'private', u'api_auth_token'), 'rb') as f:
         token = f.read()

--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,7 @@ setup(name="magic_folder",
       setup_requires=setup_requires,
       entry_points = {
           "console_scripts": [
-              "magic-folder = magic_folder.scripts.magic_folder_cli:run",
+              "magic-folder = magic_folder.cli:run",
           ],
       },
       **setup_args

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -118,21 +118,21 @@ from allmydata.client import (
     read_config,
 )
 
-from magic_folder.frontends.magic_folder import (
+from .frontends.magic_folder import (
     MagicFolder,
     load_magic_folders,
     save_magic_folders,
     maybe_upgrade_magic_folders,
 )
-from web.magic_folder import (
+from .web.magic_folder import (
     magic_folder_web_service,
 )
 
-from status import (
+from .status import (
     status as _status,
 )
 
-from _coverage import (
+from ._coverage import (
     coverage_service,
 )
 

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -118,21 +118,21 @@ from allmydata.client import (
     read_config,
 )
 
-from ..frontends.magic_folder import (
+from magic_folder.frontends.magic_folder import (
     MagicFolder,
     load_magic_folders,
     save_magic_folders,
     maybe_upgrade_magic_folders,
 )
-from ..web.magic_folder import (
+from web.magic_folder import (
     magic_folder_web_service,
 )
 
-from ..status import (
+from status import (
     status as _status,
 )
 
-from .._coverage import (
+from _coverage import (
     coverage_service,
 )
 

--- a/src/magic_folder/test/cli/common.py
+++ b/src/magic_folder/test/cli/common.py
@@ -24,7 +24,7 @@ from eliot import (
 
 from ..common_util import ReallyEqualMixin, run_cli
 
-from ...scripts.magic_folder_cli import (
+from ...cli import (
     MagicFolderCommand,
     do_magic_folder,
 )

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -50,9 +50,8 @@ from allmydata.util.eliotutil import (
 from ...frontends.magic_folder import (
     MagicFolder,
 )
-from ...scripts import (
-    magic_folder_cli,
-)
+from magic_folder import cli as magic_folder_cli
+
 from ...web.magic_folder import (
     status_for_item,
 )

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -50,7 +50,7 @@ from allmydata.util.eliotutil import (
 from ...frontends.magic_folder import (
     MagicFolder,
 )
-from magic_folder import cli as magic_folder_cli
+from ... import cli as magic_folder_cli
 
 from ...web.magic_folder import (
     status_for_item,

--- a/src/magic_folder/test/common_util.py
+++ b/src/magic_folder/test/common_util.py
@@ -14,7 +14,7 @@ from allmydata.util.encodingutil import (unicode_platform, get_filesystem_encodi
                                          get_io_encoding)
 from allmydata.scripts import runner
 
-from ..scripts.magic_folder_cli import (
+from ..cli import (
     MagicFolderCommand,
 )
 

--- a/src/twisted/plugins/magic_folder_dropin.py
+++ b/src/twisted/plugins/magic_folder_dropin.py
@@ -4,7 +4,7 @@ from twisted.application.service import (
 
 magic_folder = ServiceMaker(
     "Magic-Folder for Tahoe-LAFS",
-    "magic_folder.scripts.magic_folder_cli",
+    "magic_folder.cli",
     "Tahoe-LAFS-based file synchronization",
     "magic_folder",
 )


### PR DESCRIPTION
started a bit of re-org while getting up to speed on "stand-alone magic-folder". It did occur to me that maybe re-orgs are disruptive ... but this one is at least "just one file"...? (Anyway, we could hold off on this if that seems like a good idea).

https://github.com/LeastAuthority/magic-folder/issues/6