### PR TITLE
refactor the join command

### DIFF
--- a/src/magic_folder/scripts/magic_folder_cli.py
+++ b/src/magic_folder/scripts/magic_folder_cli.py
@@ -418,7 +418,7 @@ def join(options):
 
         rc = _join(invite_code, node_directory, local_directory, name, poll_interval)
     except Exception as e:
-        print("{}".format(e), file=options.stderr)
+        print(e, file=options.stderr)
         return 1
 
     return rc

--- a/src/magic_folder/scripts/magic_folder_cli.py
+++ b/src/magic_folder/scripts/magic_folder_cli.py
@@ -418,7 +418,7 @@ def join(options):
 
         rc = _join(invite_code, node_directory, local_directory, name, poll_interval)
     except Exception as e:
-        print("%s" % str(e), file=options.stderr)
+        print("{}".format(e), file=options.stderr)
         return 1
 
     return rc

--- a/src/magic_folder/scripts/magic_folder_cli.py
+++ b/src/magic_folder/scripts/magic_folder_cli.py
@@ -372,6 +372,9 @@ class JoinOptions(BasedirOptions):
         self.invite_code = to_str(argv_to_unicode(invite_code))
 
 def _join(invite_code, node_directory, local_dir, name, poll_interval):
+    """
+    Join a magic-folder specified by the ``name`` and create the config files.
+    """
     fields = invite_code.split(INVITE_SEPARATOR)
     if len(fields) != 2:
         raise usage.UsageError("Invalid invite code.")
@@ -403,6 +406,9 @@ def _join(invite_code, node_directory, local_dir, name, poll_interval):
     return 0
 
 def join(options):
+    """
+    ``magic-folder join`` entrypoint.
+    """
     try:
         invite_code = options.invite_code
         node_directory = options["node-directory"]


### PR DESCRIPTION
`join` is split into an outer function that interacts with the command line options and another which does the core functionality. This would eventually move the command implementations closer to the main magic-folder module.