### PR TITLE
add docstring, exit if we can't listen

### DIFF
--- a/newsfragments/67.bugfix
+++ b/newsfragments/67.bugfix
@@ -1,0 +1,1 @@
+Exit magic-folder entirely if we can't listen on startup

--- a/src/magic_folder/web/magic_folder.py
+++ b/src/magic_folder/web/magic_folder.py
@@ -18,13 +18,26 @@ from allmydata.util.hashutil import (
     timing_safe_compare,
 )
 
+
 def magic_folder_web_service(web_endpoint, get_magic_folder, get_auth_token):
+    """
+    :param get_magic_folder: a callable taking a `nickname` and
+        returning a MagicFolder
+
+    :param get_auth_token: a callable returning the current auth-token
+
+    :returns: a new IService implementing the token-based Web API
+    """
     root = Resource()
     root.putChild(b"api", MagicFolderWebApi(get_magic_folder, get_auth_token))
-    return StreamServerEndpointService(
+    srv = StreamServerEndpointService(
         web_endpoint,
         Site(root),
     )
+    srv._raiseSynchronously = True
+    return srv
+
+
 
 def error(request, code, message):
     request.setResponseCode(code, message)


### PR DESCRIPTION
Don't see any other way to get the Service to stop eating the exception .. even if the API starts with `_` ..
See https://github.com/LeastAuthority/magic-folder/issues/67