### PR TITLE
Helper to convert api_endpoint into DecodedURL

### DIFF
--- a/src/magic_folder/_endpoint_parser.py
+++ b/src/magic_folder/_endpoint_parser.py
@@ -1,0 +1,68 @@
+# Copyright 2020 Least Authority TFA GmbH
+# See COPYING for details.
+
+"""
+Turn Twisted endpoint description strings into HTTP(S) URLs.
+"""
+
+from hyperlink import (
+    URL,
+)
+
+def endpoint_description_to_http_api_root(endpoint_description):
+    """
+    Parse a Twisted endpoint description string and return a ``DecodedURL`` an
+    HTTP client could use to talk to an HTTP server listening on that
+    endpoint.
+
+    This currently supports only **tcp** and **ssl** endpoints.
+
+    :param unicode endpoint_description: The endpoint description string.
+
+    :return DecodedURL: A URL for reaching the given endpoint.
+    """
+    parts = endpoint_description.split(u":")
+    return _ENDPOINT_CONVERTERS[parts[0].lower()](parts[1:])
+
+
+def _tcp_to_http_api_root(parts):
+    """
+    Construct an HTTP URL.
+    """
+    port, host = _get_tcpish_parts(parts)
+    return URL(
+        scheme=u"http",
+        host=host,
+        port=port,
+    ).get_decoded_url()
+
+
+def _ssl_to_https_api_root(parts):
+    """
+    Construct an HTTPS URL.
+    """
+    port, host = _get_tcpish_parts(parts)
+    return URL(
+        scheme=u"https",
+        host=host,
+        port=port,
+    ).get_decoded_url()
+
+
+def _get_tcpish_parts(parts):
+    """
+    Split up the details of an endpoint with a host and port number (like
+    **tcp** and **ssl**).
+    """
+    port_number = int(parts.pop(0))
+    kwargs = dict(part.split(u"=", 1) for part in parts)
+    interface = kwargs.get(u"interface", u"127.0.0.1")
+    if interface == u"0.0.0.0":
+        interface = u"127.0.0.1"
+    return port_number, interface
+
+
+_ENDPOINT_CONVERTERS = {
+    u"tcp": _tcp_to_http_api_root,
+    u"ssl": _ssl_to_https_api_root,
+}

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -8,6 +8,16 @@ from __future__ import (
     unicode_literals,
 )
 
+__all__ = [
+    "ConfigurationError",
+    "MagicFolderConfig",
+    "GlobalConfigDatabase",
+
+    "endpoint_description_to_http_api_root",
+    "create_global_configuration",
+    "load_global_configuration",
+]
+
 from os import (
     urandom,
 )
@@ -38,6 +48,11 @@ from .snapshot import (
 )
 from .common import (
     atomic_makedirs,
+)
+
+# Export this here since GlobalConfigDatabase is what it's for.
+from ._endpoint_parser import (
+    endpoint_description_to_http_api_root,
 )
 
 

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -24,6 +24,7 @@ from nacl.signing import (
 from hypothesis.strategies import (
     just,
     one_of,
+    sampled_from,
     booleans,
     characters,
     text,
@@ -270,3 +271,25 @@ def remote_authors(names=author_names(), verify_keys=verify_keys()):
         name=names,
         verify_key=verify_keys,
     )
+
+
+def port_numbers():
+    """
+    Build ``int`` port numbers in a valid range for TCP.
+    """
+    return integers(min_value=1, max_value=2 ** 16 - 1)
+
+
+def interfaces():
+    """
+    Build ``unicode`` strings that might represent an interface string in a
+    Twisted string endpoint description.
+    """
+    return sampled_from([
+        u"127.0.0.1",
+        u"10.0.0.1",
+        u"0.0.0.0",
+        # Pick an uncommon address from the documentation range
+        # https://en.wikipedia.org/wiki/Reserved_IP_addresses
+        u"192.0.2.123",
+    ])


### PR DESCRIPTION
Fixes #222 

There didn't seem to be any particular reason to tie this tightly to GlobalConfigDatabase.api_endpoint so I didn't.  It's just a helper you can use with that value.
