### PR TITLE
Use pip cache in GitHub Actions

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -27,7 +27,9 @@ jobs:
     - name: Use pip cache
       uses: actions/cache@v2
       with:
-        path: ~/Library/Caches/pip
+        path:
+          - ~/Library/Caches/pip
+          - ./wheelhouse
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
             ${{ runner.os }}-pip-

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -23,6 +23,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    # See https://github.com/actions/cache/blob/master/examples.md#python---pip
     - name: Use pip cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -41,10 +41,10 @@ jobs:
       run: pip -v download . --dest ./wheelhouse
 
     - name: Test with tox
-      env:
+      env: |
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
-      run: |
-        PIP_FIND_LINKS=./wheelhouse tox -e py27-coverage
+        PIP_FIND_LINKS: ./wheelhouse
+      run: tox -e py27-coverage
 
     - uses: codecov/codecov-action@v1
       with:
@@ -87,8 +87,8 @@ jobs:
       run: pip -v download . --dest ./wheelhouse
 
     - name: Test with tox
-      run: |
-        PIP_FIND_LINKS=./wheelhouse tox -vvv -e integration
+      env: PIP_FIND_LINKS:./wheelhouse
+      run: tox -vvv -e integration
 
     - uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,6 +37,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel tox
 
+    - name: Populate wheelhouse
+      run: pip -v download . --dest ./wheelhouse
+
     - name: Test with tox
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
@@ -79,6 +82,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel tox
+
+    - name: Populate wheelhouse
+      run: pip -v download . --dest ./wheelhouse
+
     - name: Test with tox
       run: |
         PIP_FIND_LINKS=./wheelhouse tox -vvv -e integration

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -34,8 +34,10 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-pip-
 
+    # Packages with pinned versions are from tox.ini; we will have to
+    # update them if/when tox.ini changes.
     - name: Populate wheelhouse
-      run: pip -v download . --dest ./wheelhouse
+      run: pip wheel --wheel-dir ./wheelhouse $(pwd)[test] pip==19.1.1 setuptools==41.0.1 wheel==0.33.4  subunitreporter==19.3.2 tox codecov python-subunit junitxml
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,7 +37,7 @@ jobs:
     # Packages with pinned versions are from tox.ini; we will have to
     # update them if/when tox.ini changes.
     - name: Populate wheelhouse
-      run: pip wheel --wheel-dir ./wheelhouse $(pwd)[test] pip==19.1.1 setuptools==41.0.1 wheel==0.33.4  subunitreporter==19.3.2 tox codecov python-subunit junitxml
+      run: pip download --dest ./wheelhouse $(pwd)[test] pip==19.1.1 setuptools==41.0.1 wheel==0.33.4  subunitreporter==19.3.2 tox codecov python-subunit junitxml
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -44,6 +44,7 @@ jobs:
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
         PIP_FIND_LINKS: ./wheelhouse
+        PIP_NO_INDEX: true
       run: tox -e py27-coverage
 
     - uses: codecov/codecov-action@v1
@@ -89,6 +90,7 @@ jobs:
     - name: Test with tox
       env:
         PIP_FIND_LINKS: ./wheelhouse
+        PIP_NO_INDEX: true
       run: tox -vvv -e integration
 
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -87,7 +87,8 @@ jobs:
       run: pip -v download . --dest ./wheelhouse
 
     - name: Test with tox
-      env: PIP_FIND_LINKS:./wheelhouse
+      env:
+        PIP_FIND_LINKS: ./wheelhouse
       run: tox -vvv -e integration
 
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -27,9 +27,9 @@ jobs:
     - name: Use pip cache
       uses: actions/cache@v2
       with:
-        path:
-          - ~/Library/Caches/pip
-          - ./wheelhouse
+        path: |
+          ~/Library/Caches/pip
+          ./wheelhouse
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
             ${{ runner.os }}-pip-

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -48,7 +48,6 @@ jobs:
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
         PIP_FIND_LINKS: ./wheelhouse
-        PIP_NO_INDEX: true
       run: tox -e py27-coverage
 
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -45,6 +45,7 @@ jobs:
     - name: Test with tox
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
+        PIP_FIND_LINKS: ./wheelhouse
       run: tox -e py27-coverage
 
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -34,6 +34,9 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-pip-
 
+    - name: Populate wheelhouse
+      run: pip -v download . --dest ./wheelhouse
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -25,7 +25,6 @@ jobs:
 
     - name: Use pip cache
       uses: actions/cache@v2
-      if: startsWith(runner.os, 'macOS')
       with:
         path: ~/Library/Caches/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
@@ -69,7 +68,6 @@ jobs:
 
     - name: Use pip cache
       uses: actions/cache@v2
-      if: startsWith(runner.os, 'macOS')
       with:
         path: ~/Library/Caches/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -44,7 +44,6 @@ jobs:
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
         PIP_FIND_LINKS: ./wheelhouse
-        PIP_NO_INDEX: true
       run: tox -e py27-coverage
 
     - uses: codecov/codecov-action@v1
@@ -90,7 +89,6 @@ jobs:
     - name: Test with tox
       env:
         PIP_FIND_LINKS: ./wheelhouse
-        PIP_NO_INDEX: true
       run: tox -vvv -e integration
 
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -17,14 +17,26 @@ jobs:
         fetch-depth: "0"
     # Get tags not fetched by the checkout action, needed for auto-versioning.
     - run: "git fetch origin +refs/tags/*:refs/tags/*"
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Use pip cache
+      uses: actions/cache@v2
+      if: startsWith(runner.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+            ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install wheel tox
+
     - name: Test with tox
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -81,7 +81,7 @@ jobs:
         pip install wheel tox
     - name: Test with tox
       run: |
-        PIP_FIND_LINKS=./wheelhouse tox -e integration
+        PIP_FIND_LINKS=./wheelhouse tox -vvv -e integration
 
     - uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,7 +37,7 @@ jobs:
     # Packages with pinned versions are from tox.ini; we will have to
     # update them if/when tox.ini changes.
     - name: Populate wheelhouse
-      run: pip download --dest ./wheelhouse $(pwd)[test] pip==19.1.1 setuptools==41.0.1 wheel==0.33.4  subunitreporter==19.3.2 tox codecov python-subunit junitxml
+      run: pip download --dest ./wheelhouse $(pwd)[test]
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -61,10 +61,21 @@ jobs:
         fetch-depth: "0"
     # Get tags not fetched by the checkout action, needed for auto-versioning.
     - run: "git fetch origin +refs/tags/*:refs/tags/*"
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Use pip cache
+      uses: actions/cache@v2
+      if: startsWith(runner.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        restore-keys: |
+            ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -80,7 +80,7 @@ jobs:
         pip install wheel tox
 
     - name: Test with tox
-      run: tox -vvv -e integration
+      run: tox -e integration
 
     - uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -28,7 +28,7 @@ jobs:
       if: startsWith(runner.os, 'macOS')
       with:
         path: ~/Library/Caches/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -46,6 +46,7 @@ jobs:
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
         PIP_FIND_LINKS: ./wheelhouse
+        PIP_NO_INDEX: true
       run: tox -e py27-coverage
 
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -41,7 +41,7 @@ jobs:
       run: pip -v download . --dest ./wheelhouse
 
     - name: Test with tox
-      env: |
+      env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
         PIP_FIND_LINKS: ./wheelhouse
       run: tox -e py27-coverage

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -37,13 +37,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel tox
 
-    - name: Populate wheelhouse
-      run: pip -v download . --dest ./wheelhouse
-
     - name: Test with tox
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
-        PIP_FIND_LINKS: ./wheelhouse
       run: tox -e py27-coverage
 
     - uses: codecov/codecov-action@v1
@@ -83,12 +79,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel tox
 
-    - name: Populate wheelhouse
-      run: pip -v download . --dest ./wheelhouse
-
     - name: Test with tox
-      env:
-        PIP_FIND_LINKS: ./wheelhouse
       run: tox -vvv -e integration
 
     - uses: codecov/codecov-action@v1


### PR DESCRIPTION
This is related to #238.

- [Example CI run without cache](https://github.com/LeastAuthority/magic-folder/runs/955252273?check_suite_focus=true): 21s to install dependencies.
- [Example CI run with cache](https://github.com/LeastAuthority/magic-folder/runs/958673132?check_suite_focus=true): 9s to install dependencies.