### PR TITLE
Remove create_local_author_from_config and write_local_author

### DIFF
--- a/src/magic_folder/snapshot.py
+++ b/src/magic_folder/snapshot.py
@@ -113,57 +113,6 @@ def create_local_author(name):
     )
 
 
-def write_local_author(local_author, magic_folder_name, config):
-    """
-    Writes a LocalAuthor instance beside other magic-folder data in the node-directory
-    """
-    key_fname = "magicfolder_{}.privkey".format(magic_folder_name)
-    path = config.get_config_path("private", key_fname)
-    keydata_base64 = local_author.signing_key.encode(encoder=Base64Encoder)
-    author_data = {
-        "author_name": local_author.name,
-        "author_private_key": keydata_base64,
-    }
-    with open(path, "w") as f:
-        json.dump(author_data, f)
-
-
-def create_local_author_from_config(config, name=None):
-    """
-    :param config: a Tahoe config instance (created via `allmydata.client.read_config`)
-
-    :param name: which Magic Folder to use (or 'default')
-
-    :returns: a LocalAuthor instance from our configuration
-    """
-    # private-keys go in "<node_dir>/private/magicfolder_<name>.privkey"
-    # to mirror where the sqlite database goes
-    if name is None:
-        name = "default"
-    nodedir = config.get_config_path()
-    import magic_folder
-    magic_folders = magic_folder.load_magic_folders(nodedir)
-    if name not in magic_folders:
-        raise RuntimeError(
-            "No magic-folder named '{}'".format(name)
-        )
-
-    # we will always have authorship information for this
-    # magic-folder; "legacy" magic-folders will go through "tahoe
-    # migrate" first and have an author created.
-
-    author_raw = config.get_private_config("magicfolder_{}.privkey".format(name))
-    author_data = json.loads(author_raw)
-
-    return LocalAuthor(
-        name=author_data[u"author_name"],
-        signing_key=SigningKey(
-            author_data[u"author_private_key"],
-            encoder=Base64Encoder,
-        ),
-    )
-
-
 def create_author(name, verify_key):
     """
     :param name: arbitrary name for this author

--- a/src/magic_folder/snapshot.py
+++ b/src/magic_folder/snapshot.py
@@ -100,11 +100,12 @@ class LocalAuthor(object):
 
 def create_local_author(name):
     """
-    Create a new local author with a freshly generated private
-    (signing) key. This author will not be saved on disk anywhere; see
-    `write_local_author` to do that.
+    Create a new local author with a freshly generated private (signing) key.
 
-    :param name: the name of this author
+    :param unicode name: the name of this author
+
+    :return LocalAuthor: A new ``LocalAuthor`` with the given name and a
+        randomly generated private key.
     """
     signing_key = SigningKey.generate()
     return LocalAuthor(

--- a/src/magic_folder/test/test_snapshot.py
+++ b/src/magic_folder/test/test_snapshot.py
@@ -58,10 +58,8 @@ from .strategies import (
 )
 from magic_folder.snapshot import (
     create_local_author,
-    create_local_author_from_config,
     create_author_from_json,
     create_author,
-    write_local_author,
     create_snapshot,
     create_snapshot_from_capability,
     write_snapshot_to_tahoe,
@@ -72,48 +70,6 @@ from magic_folder.snapshot import (
 from magic_folder.tahoe_client import (
     create_tahoe_client,
 )
-
-class TestLocalAuthor(SyncTestCase):
-    """
-    Functionaltiy of LocalAuthor instances
-    """
-
-    def setUp(self):
-        d = super(TestLocalAuthor, self).setUp()
-        magic_dir = FilePath(mktemp())
-        self.node = self.useFixture(NodeDirectory(FilePath(mktemp())))
-        self.node.create_magic_folder(
-            u"default",
-            u"URI:CHK2:{}:{}:1:1:256".format(u"a"*16, u"a"*32),
-            u"URI:CHK2:{}:{}:1:1:256".format(u"b"*16, u"b"*32),
-            magic_dir,
-            60,
-        )
-
-        self.config = read_config(self.node.path.path, "portnum")
-
-        return d
-
-    def test_serialize_author(self):
-        """
-        Write and then read a LocalAuthor to our node-directory
-        """
-        alice = create_local_author("alice")
-        self.assertThat(alice.name, Equals("alice"))
-
-        # serialize the author to disk
-        write_local_author(alice, "default", self.config)
-
-        # read back the author
-        alice2 = create_local_author_from_config(self.config)
-        self.assertThat(
-            alice2,
-            MatchesStructure(
-                name=Equals("alice"),
-                verify_key=Equals(alice.verify_key),
-            )
-        )
-
 
 class TestRemoteAuthor(SyncTestCase):
     """


### PR DESCRIPTION
Fixes #260 

Both APIs are just deleted.  create_local_author_from_config was obsoleted by `MagicFolderConfig.author` and `write_local_author` was obsoleted by `GlobalConfigDatabase.create_magic_folder` (soon to be `MagicFolderConfig.initialize`).
