### PR TITLE
'magic-folder list' uses HTTP API instead

### DIFF
--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -28,16 +28,33 @@ the client should re-read the token from the filesystem to determine if the valu
 ``GET /v1/magic-folder``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This endpoint returns a list of all individual magic-folders managed by this daemon.
+This endpoint returns a dict of all individual magic-folders managed
+by this daemon. The keys of the dict are the folder name and the
+values are themselves dicts.
+
+You may include the query argument ``?include_secret_information=1`` to
+include values for each folder which should be kept hidden (and are
+not shown by default). These are: ``upload_dircap``,
+``collective_dircap``, and the ``signing_key`` inside ``author``.
 
 The response code **OK** and the **Content-Type** is ``application/json``.
-The response body follows the form of this example::
+The response body follows the form of this example (containing a single
+magic-folder named "documents")::
 
-  { "folders":
-    [ { "name": "Alice's music", "local-path": "/home/alice/Music" }
-    , { "name": "Secret docs", "local-path": /home/alice/secrets" }
-    ]
-  }
+    {
+        "documents": {
+            "name": "documents",
+            "author": {
+                "name": "alice",
+                "verify_key": "OY7FCVPCOJXDNHQLSDTTJFONTROMQQED5Q6K33T3NBGGQHKLV73Q===="
+            },
+            "poll_interval": 60,
+            "is_admin": true,
+            "stash_path": "/home/alice/.config/magic-folder/documents",
+            "magic_path": "/home/alice/Documents"
+        }
+    }
+
 
 ``GET /v1/snapshot``
 ~~~~~~~~~~~~~~~~~~~~

--- a/integration/test_list.py
+++ b/integration/test_list.py
@@ -1,0 +1,51 @@
+from json import (
+    loads,
+)
+
+import pytest_twisted
+
+from eliot import (
+    start_action,
+)
+
+import util
+
+# see "conftest.py" for the fixtures (e.g. "magic_folder")
+
+
+@pytest_twisted.inlineCallbacks
+def test_list(request, reactor, temp_dir, introducer_furl, flog_gatherer):
+    """
+    'magic-folder list' happy-path works
+    """
+
+    print("-"*80)
+    print("create zelda")
+    with start_action(action_type=u"integration:test_list:zelda", include_args=[], include_result=False):
+        zelda = yield util.MagicFolderEnabledNode.create(
+            reactor,
+            request,
+            temp_dir,
+            introducer_furl,
+            flog_gatherer,
+            name="zelda",
+            tahoe_web_port="tcp:9982:interface=localhost",
+            magic_folder_web_port="tcp:19982:interface=localhost",
+            storage=True,
+        )
+    print("zelda", zelda)
+
+    proto = util._CollectOutputProtocol()
+    util._magic_folder_runner(
+        proto, reactor, request,
+        [
+            "--config", zelda.magic_config_directory,
+            "list",
+        ],
+    )
+    output = yield proto.done
+    print("-" * 80)
+    print(output)
+    print("-" * 80)
+    assert output.strip() == "No magic-folders"
+

--- a/integration/test_list.py
+++ b/integration/test_list.py
@@ -19,8 +19,6 @@ def test_list(request, reactor, temp_dir, introducer_furl, flog_gatherer):
     'magic-folder list' happy-path works
     """
 
-    print("-"*80)
-    print("create zelda")
     with start_action(action_type=u"integration:test_list:zelda", include_args=[], include_result=False):
         zelda = yield util.MagicFolderEnabledNode.create(
             reactor,
@@ -33,7 +31,6 @@ def test_list(request, reactor, temp_dir, introducer_furl, flog_gatherer):
             magic_folder_web_port="tcp:19982:interface=localhost",
             storage=True,
         )
-    print("zelda", zelda)
 
     proto = util._CollectOutputProtocol()
     util._magic_folder_runner(
@@ -44,8 +41,5 @@ def test_list(request, reactor, temp_dir, introducer_furl, flog_gatherer):
         ],
     )
     output = yield proto.done
-    print("-" * 80)
-    print(output)
-    print("-" * 80)
     assert output.strip() == "No magic-folders"
 

--- a/integration/test_list.py
+++ b/integration/test_list.py
@@ -1,6 +1,3 @@
-from json import (
-    loads,
-)
 
 import pytest_twisted
 

--- a/integration/test_list.py
+++ b/integration/test_list.py
@@ -7,6 +7,9 @@ from twisted.python.filepath import (
 
 import pytest_twisted
 
+from eliot.twisted import (
+    inline_callbacks,
+)
 from eliot import (
     start_action,
 )
@@ -15,7 +18,10 @@ import util
 
 # see "conftest.py" for the fixtures (e.g. "magic_folder")
 
+# we need the eliot decorator too so that start_action works properly;
+# the pytest decorator actually only "marks" the function
 
+@inline_callbacks
 @pytest_twisted.inlineCallbacks
 def test_list(request, reactor, temp_dir, introducer_furl, flog_gatherer):
     """

--- a/integration/test_magic_folder.py
+++ b/integration/test_magic_folder.py
@@ -2,12 +2,12 @@ from os.path import join, exists
 
 # see "conftest.py" for the fixtures (e.g. "magic_folder")
 
-def test_eliot_logs_are_written(alice, bob, temp_dir):
+def test_eliot_logs_are_written(alice, bob):
     # The integration test configuration arranges for this logging
     # configuration.  Verify it actually does what we want.
     #
     # The alice and bob arguments looks unused but they actually tell pytest
     # to set up all the magic-folder stuff.  The assertions here are about
     # side-effects of that setup.
-    assert exists(join(temp_dir, "alice", "logs", "eliot.json"))
-    assert exists(join(temp_dir, "bob", "logs", "eliot.json"))
+    assert exists(join(alice.node_directory, "logs", "eliot.json"))
+    assert exists(join(bob.node_directory, "logs", "eliot.json"))

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -110,6 +110,10 @@ from .invite import (
     magic_folder_invite
 )
 
+from .list import (
+    magic_folder_list
+)
+
 from .create import (
     magic_folder_create
 )
@@ -352,6 +356,8 @@ class ListOptions(usage.Options):
     ]
 
 
+
+@inlineCallbacks
 def list_(options):
     """
     List existing magic-folders.

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -3,17 +3,12 @@ from __future__ import unicode_literals
 
 import sys
 import getpass
-import traceback
 from six.moves import (
     StringIO as MixedIO,
 )
 import json
 from collections import (
     defaultdict,
-)
-
-from nacl.encoding import (
-    Base32Encoder,
 )
 
 from appdirs import (

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -102,7 +102,7 @@ from .web import (
 )
 from .client import (
     create_http_client,
-    CannotAccessApiError,
+    CannotAccessAPIError,
 )
 
 from .invite import (
@@ -1090,7 +1090,7 @@ def run_magic_folder_options(options):
         try:
             yield maybeDeferred(f, so)
 
-        except CannotAccessApiError as e:
+        except CannotAccessAPIError as e:
             # give user more information if we can't find the daemon at all
             print(u"Error: {}".format(e), file=options.stderr)
             print(u"   Attempted access via {}".format(options.config.api_client_endpoint))

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -350,45 +350,12 @@ def list_(options):
     """
     List existing magic-folders.
     """
-    mf_info = yield magic_folder_list(options.parent.config, options["include-secret-information"])
-    mf_info = mf_info["folders"]
-    if options["json"]:
-        print(json.dumps(mf_info, indent=4), file=options.stdout)
-        return
-    _list_human(mf_info, options.stdout, options["include-secret-information"])
-    return
-
-
-def _list_human(info, stdout, include_secrets):
-    """
-    List our magic-folders for a human user.
-    """
-    if include_secrets:
-        template = (
-            "    location: {magic_path}\n"
-            "   stash-dir: {stash_path}\n"
-            "      author: {author[name]} (private_key: {author[signing_key]})\n"
-            "  collective: {collective_dircap}\n"
-            "    personal: {upload_dircap}\n"
-            "     updates: every {poll_interval}s\n"
-            "       admin: {is_admin}\n"
-        )
-    else:
-        template = (
-            "    location: {magic_path}\n"
-            "   stash-dir: {stash_path}\n"
-            "      author: {author[name]} (public_key: {author[verify_key]})\n"
-            "     updates: every {poll_interval}s\n"
-            "       admin: {is_admin}\n"
-        )
-
-    if info:
-        print("Configured magic-folders:", file=stdout)
-        for details in info:
-            print("{}:".format(details["name"]), file=stdout)
-            print(template.format(**details).rstrip("\n"), file=stdout)
-    else:
-        print("No magic-folders", file=stdout)
+    yield magic_folder_list(
+        options.parent.config,
+        options.stdout,
+        options["json"],
+        options["include-secret-information"],
+    )
 
 
 class InviteOptions(usage.Options):

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -340,9 +340,6 @@ class ListOptions(usage.Options):
         ("json", "", "Produce JSON output"),
         ("include-secret-information", "", "Include sensitive secret data too"),
     ]
-    optParameters = [
-        ("config", "c", None, "An existing config directory (default {}".format(_default_config_path)),
-    ]
 
 
 @inlineCallbacks

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -424,7 +424,7 @@ def _list_human(info, stdout, include_secrets):
         )
 
     if info:
-        print("This client has the following magic-folders:", file=stdout)
+        print("Configured magic-folders:", file=stdout)
         for details in info:
             print("{}:".format(details["name"]), file=stdout)
             print(template.format(**details).rstrip("\n"), file=stdout)

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -365,6 +365,7 @@ def list_(options):
     List existing magic-folders.
     """
     mf_info = yield magic_folder_list(options.parent.config)
+    mf_info = mf_info["folders"]
     if options["json"]:
         print(json.dumps(mf_info, indent=4), file=options.stdout)
         return
@@ -424,8 +425,8 @@ def _list_human(info, stdout, include_secrets):
 
     if info:
         print("This client has the following magic-folders:", file=stdout)
-        for name, details in info.items():
-            print("{}:".format(name), file=stdout)
+        for details in info:
+            print("{}:".format(details["name"]), file=stdout)
             print(template.format(**details).rstrip("\n"), file=stdout)
     else:
         print("No magic-folders", file=stdout)

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -373,33 +373,6 @@ def list_(options):
     return
 
 
-def _magic_folder_info(options):
-    """
-    Get information about all magic-folders
-
-    :returns: JSON-able dict
-    """
-    info = dict()
-    config = options.parent.config
-    for name in config.list_magic_folders():
-        mf = config.get_magic_folder(name)
-        info[name] = {
-            u"author": {
-                u"name": mf.author.name,
-                u"verify_key": mf.author.verify_key.encode(Base32Encoder),
-            },
-            u"stash_path": mf.stash_path.path,
-            u"magic_path": mf.magic_path.path,
-            u"poll_interval": mf.poll_interval,
-            u"is_admin": mf.is_admin(),
-        }
-        if options['include-secret-information']:
-            info[name][u"author"][u"signing_key"] = mf.author.signing_key.encode(Base32Encoder)
-            info[name][u"collective_dircap"] = mf.collective_dircap.encode("ascii")
-            info[name][u"upload_dircap"] = mf.upload_dircap.encode("ascii")
-    return info
-
-
 def _list_human(info, stdout, include_secrets):
     """
     List our magic-folders for a human user.

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -398,7 +398,7 @@ def _magic_folder_info(options):
 
 def _list_human(info, stdout, include_secrets):
     """
-    List our magic-folders for a human user
+    List our magic-folders for a human user.
     """
     if include_secrets:
         template = (

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -354,8 +354,9 @@ class ListOptions(usage.Options):
         ("json", "", "Produce JSON output"),
         ("include-secret-information", "", "Include sensitive secret data too"),
     ]
-
-
+    optParameters = [
+        ("config", "c", None, "An existing config directory (default {}".format(_default_config_path)),
+    ]
 
 @inlineCallbacks
 def list_(options):

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -358,16 +358,18 @@ class ListOptions(usage.Options):
         ("config", "c", None, "An existing config directory (default {}".format(_default_config_path)),
     ]
 
+
 @inlineCallbacks
 def list_(options):
     """
     List existing magic-folders.
     """
-    mf_info = _magic_folder_info(options)
+    mf_info = yield magic_folder_list(options.parent.config)
     if options["json"]:
         print(json.dumps(mf_info, indent=4), file=options.stdout)
         return
-    return _list_human(mf_info, options.stdout, options["include-secret-information"])
+    _list_human(mf_info, options.stdout, options["include-secret-information"])
+    return
 
 
 def _magic_folder_info(options):

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -101,6 +101,7 @@ from .web import (
     magic_folder_web_service,
 )
 from .client import (
+    create_http_client,
     CannotAccessApiError,
 )
 
@@ -351,6 +352,7 @@ def list_(options):
     yield magic_folder_list(
         reactor,
         options.parent.config,
+        create_http_client(reactor, options.parent.config.api_client_endpoint),
         options.stdout,
         options["json"],
         options["include-secret-information"],

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -347,7 +347,9 @@ def list_(options):
     """
     List existing magic-folders.
     """
+    from twisted.internet import reactor
     yield magic_folder_list(
+        reactor,
         options.parent.config,
         options.stdout,
         options["json"],

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -364,7 +364,7 @@ def list_(options):
     """
     List existing magic-folders.
     """
-    mf_info = yield magic_folder_list(options.parent.config)
+    mf_info = yield magic_folder_list(options.parent.config, options["include-secret-information"])
     mf_info = mf_info["folders"]
     if options["json"]:
         print(json.dumps(mf_info, indent=4), file=options.stdout)

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -1,0 +1,175 @@
+# Copyright 2020 Least Authority TFA GmbH
+# See COPYING for details.
+
+import json
+
+from twisted.internet.defer import (
+    inlineCallbacks,
+    returnValue,
+)
+from twisted.internet.endpoints import (
+    clientFromString,
+)
+from twisted.internet.error import (
+    ConnectError,
+)
+
+from twisted.web import (
+    http,
+)
+from twisted.web.client import (
+    Agent,
+)
+from twisted.web.iweb import (
+    IAgentEndpointFactory,
+)
+
+from zope.interface import (
+    implementer,
+)
+
+from hyperlink import (
+    DecodedURL,
+)
+
+from treq.client import (
+    HTTPClient,
+)
+
+import attr
+
+
+class ClientError(Exception):
+    """
+    Base class for all exceptions in this module
+    """
+
+class CannotAccessApiError(ClientError):
+    """
+    The Magic Folder HTTP API can't be reached at all
+    """
+
+
+@attr.s(frozen=True)
+class MagicFolderApiError(ClientError):
+    """
+    A Magic Folder HTTP API returned a failure code.
+    """
+    code = attr.ib()
+    body = attr.ib()
+
+    def __repr__(self):
+        return "<MagicFolderApiError code={} body={!r}>".format(
+            self.code,
+            self.body,
+        )
+
+    def __str__(self):
+        return u"Magic Folder HTTP API reported error {}: {}".format(
+            self.code,
+            self.body,
+        )
+
+
+@inlineCallbacks
+def _get_content_check_code(acceptable_codes, res):
+    """
+    Check that the given response's code is acceptable and read the response
+    body.
+
+    :raise MagicFolderApiError: If the response code is not acceptable.
+
+    :return Deferred[bytes]: If the response code is acceptable, a Deferred
+        which fires with the response body.
+    """
+    body = yield res.content()
+    if res.code not in acceptable_codes:
+        raise MagicFolderApiError(res.code, body)
+    returnValue(body)
+
+
+@attr.s
+class MagicFolderClient(object):
+    """
+    An object that knows how to call a particular Magic Folder HTTP API.
+
+    :ivar HTTPClient http_client: The client to use to make HTTP requests.
+
+    :ivar callable get_api_token: returns the current API token
+    """
+
+    # we only use the path-part not the domain
+    base_url = DecodedURL.from_text(u"http://invalid./")
+    http_client = attr.ib(validator=attr.validators.instance_of(HTTPClient))
+    get_api_token = attr.ib()
+
+    def list_folders(self, include_secret_information=None):
+        api_url = self.base_url.child(u'v1').child(u'magic-folder')
+        if include_secret_information:
+            api_url = api_url.replace(query=[(u"include_secret_information", u"1")])
+        return self._make_token_authenticated_request(api_url)
+
+    @inlineCallbacks
+    def _make_token_authenticated_request(self, url):
+        headers = {
+            b"Authorization": u"Bearer {}".format(self.get_api_token()).encode("ascii"),
+        }
+
+        try:
+            response = yield self.http_client.get(
+                url.to_uri().to_text().encode('ascii'),
+                headers=headers,
+            )
+        except ConnectError:
+            raise CannotAccessApiError(
+                "Can't reach the magic folder daemon at all"
+            )
+
+        body = yield _get_content_check_code([http.OK], response)
+        # all responses should contain JSON
+        returnValue(json.loads(body))
+
+
+
+
+
+@implementer(IAgentEndpointFactory)
+@attr.s
+class _StaticEndpointFactory(object):
+    """
+    An endpoint factory used by `create_magic_folder_client`
+
+    :ivar endpoint: the endpoint returned for every request
+    """
+
+    endpoint = attr.ib()
+
+    def endpointForURI(self, uri):
+        return self.endpoint
+
+
+def create_magic_folder_client(reactor, config):
+    """
+    Create a new MagicFolderClient instance that is speaking to the
+    magic-folder defined by ``config``.
+
+    :param GlobalConfigurationDatabase config: a Magic Folder global
+        configuration
+
+    :returns: a MagicFolderclient instance
+    """
+    def get_api_token():
+        with config.api_token_path.open('rb') as f:
+            return f.read()
+
+    endpoint = clientFromString(reactor, config.api_client_endpoint)
+
+    return MagicFolderClient(
+        http_client=HTTPClient(
+            Agent.usingEndpointFactory(
+                reactor,
+                _StaticEndpointFactory(endpoint),
+            ),
+        ),
+        get_api_token=get_api_token,
+    )

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -7,9 +7,6 @@ from twisted.internet.defer import (
     inlineCallbacks,
     returnValue,
 )
-from twisted.internet.endpoints import (
-    clientFromString,
-)
 from twisted.internet.error import (
     ConnectError,
 )

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -129,8 +129,7 @@ def create_magic_folder_client(reactor, config):
     :returns: a MagicFolderclient instance
     """
     def get_api_token():
-        with config.api_token_path.open("r") as f:
-            return f.read()
+        return config.api_token
 
     return MagicFolderClient(
         http_client=config.create_http_client(reactor),

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -17,16 +17,6 @@ from twisted.internet.error import (
 from twisted.web import (
     http,
 )
-from twisted.web.client import (
-    Agent,
-)
-from twisted.web.iweb import (
-    IAgentEndpointFactory,
-)
-
-from zope.interface import (
-    implementer,
-)
 
 from hyperlink import (
     DecodedURL,
@@ -131,24 +121,6 @@ class MagicFolderClient(object):
         returnValue(json.loads(body))
 
 
-
-
-
-@implementer(IAgentEndpointFactory)
-@attr.s
-class _StaticEndpointFactory(object):
-    """
-    An endpoint factory used by `create_magic_folder_client`
-
-    :ivar endpoint: the endpoint returned for every request
-    """
-
-    endpoint = attr.ib()
-
-    def endpointForURI(self, uri):
-        return self.endpoint
-
-
 def create_magic_folder_client(reactor, config):
     """
     Create a new MagicFolderClient instance that is speaking to the
@@ -163,14 +135,7 @@ def create_magic_folder_client(reactor, config):
         with config.api_token_path.open('rb') as f:
             return f.read()
 
-    endpoint = clientFromString(reactor, config.api_client_endpoint)
-
     return MagicFolderClient(
-        http_client=HTTPClient(
-            Agent.usingEndpointFactory(
-                reactor,
-                _StaticEndpointFactory(endpoint),
-            ),
-        ),
+        http_client=config.create_http_client(reactor),
         get_api_token=get_api_token,
     )

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -55,7 +55,7 @@ class ClientError(Exception):
     """
 
 
-class CannotAccessApiError(ClientError):
+class CannotAccessAPIError(ClientError):
     """
     The Magic Folder HTTP API can't be reached at all
     """
@@ -137,7 +137,7 @@ class MagicFolderClient(object):
             )
 
         except ConnectError:
-            raise CannotAccessApiError(
+            raise CannotAccessAPIError(
                 "Can't reach the magic folder daemon at all"
             )
 

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -132,7 +132,7 @@ def create_magic_folder_client(reactor, config):
     :returns: a MagicFolderclient instance
     """
     def get_api_token():
-        with config.api_token_path.open('rb') as f:
+        with config.api_token_path.open("r") as f:
             return f.read()
 
     return MagicFolderClient(

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -44,6 +44,7 @@ class ClientError(Exception):
     Base class for all exceptions in this module
     """
 
+
 class CannotAccessApiError(ClientError):
     """
     The Magic Folder HTTP API can't be reached at all

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -712,8 +712,11 @@ class FilesystemTokenProvider(object):
         Retrieve the current token.
         """
         if self._api_token is None:
-            with self.api_token_path.open('rb') as f:
-                self._api_token = f.read()
+            try:
+                self._load_token()
+            except OSError:
+                self.rotate()
+                self._load_token()
         return self._api_token
 
     def rotate(self):
@@ -726,6 +729,13 @@ class FilesystemTokenProvider(object):
         with self.api_token_path.open('wb') as f:
             f.write(self._api_token)
         return self._api_token
+
+    def _load_token(self):
+        """
+        Internal helper. Reads the token file into _api_token
+        """
+        with self.api_token_path.open('rb') as f:
+            self._api_token = f.read()
 
 
 @attr.s

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -687,6 +687,9 @@ class ITokenProvider(Interface):
     def get():
         """
         Retrieve the current token.
+
+        :returns: url-safe base64 encoded token (which decodes to
+            32-bytes of random binary data).
         """
 
     def rotate():

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -35,6 +35,7 @@ from functools import (
 import attr
 from attr.validators import (
     provides,
+    instance_of,
 )
 
 import sqlite3
@@ -700,7 +701,7 @@ class FilesystemTokenProvider(object):
     """
     Keep a token on the filesystem
     """
-    api_token_path = attr.ib(validator=attr.validators.instance_of(FilePath))
+    api_token_path = attr.ib(validator=instance_of(FilePath))
     _api_token = attr.ib(default=None)
 
     def get(self):
@@ -755,8 +756,9 @@ class GlobalConfigDatabase(object):
     """
     Low-level access to the global configuration database
     """
-    basedir = attr.ib()  # where magic-folder state goes
-    database = attr.ib()  # sqlite3 Connection; needs validator
+    # where magic-folder state goes
+    basedir = attr.ib(validator=instance_of(FilePath))
+    database = attr.ib(validator=instance_of(sqlite3.Connection))
     _token_provider = attr.ib(validator=provides(ITokenProvider))
 
     @property

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -78,21 +78,25 @@ def get_magic_folder_api_token_from_config_dir(config_directory):
 
 
 @inlineCallbacks
-def magic_folder_list(node_directory):
+def magic_folder_list(node_directory, config_directory=None):
     """
     List folders associated with a node.
 
-    :param options: TODO
+    :param node_directory: a Tahoe node directory.
+    :param config_directory: a Magic Folder configuration directory.
 
     :return: JSON response from `GET /v1/magic-folder`.
     """
-    base_url = get_magic_folder_api_base_url_from_node_dir(node_directory)
+    if config_directory:
+        base_url = get_magic_folder_api_base_url_config_dir(config_directory)
+        api_token = get_magic_folder_api_token_from_config_dir(config_directory)
+    else:
+        base_url = get_magic_folder_api_base_url_from_node_dir(node_directory)
+        api_token = get_magic_folder_api_token_from_node_dir(node_directory)
 
     api_url = DecodedURL.from_text(
         unicode(base_url, 'utf-8')
     ).child(u'v1').child(u'magic-folder')
-
-    api_token = get_magic_folder_api_token_from_node_dir(node_directory)
 
     headers = {
         b"Authorization": u"Bearer {}".format(api_token).encode("ascii"),

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -5,50 +5,14 @@
 Implements ```magic-folder list``` command.
 """
 
-import os
-import json
-
-from twisted.internet import reactor
 from twisted.internet.defer import (
     inlineCallbacks,
     returnValue,
 )
-from twisted.internet.error import (
-    ConnectError,
+
+from .client import (
+    create_magic_folder_client,
 )
-from twisted.internet.endpoints import (
-    clientFromString,
-)
-from twisted.web.client import (
-    Agent,
-    readBody,
-)
-from twisted.web import http
-from twisted.web.iweb import (
-    IAgentEndpointFactory,
-)
-
-from hyperlink import  DecodedURL
-from treq.client import HTTPClient
-from allmydata.client import read_config
-from zope.interface import implementer
-
-from .config import endpoint_description_to_http_api_root
-
-
-
-@implementer(IAgentEndpointFactory)
-class EndpointStringFactory(object):
-    """
-    Connect to a particular client endpoint-string
-    """
-    def __init__(self, reactor, endpoint_str):
-        self.reactor = reactor
-        self.endpoint = endpoint_str
-
-    def endpointForURI(self, uri):
-        return clientFromString(self.reactor, self.endpoint)
-
 
 
 @inlineCallbacks
@@ -63,46 +27,8 @@ def magic_folder_list(config, include_secret_information=False):
 
     :return: JSON response from `GET /v1/magic-folder`.
     """
-    base_url = DecodedURL.from_text(u"http://invalid./")
     from twisted.internet import reactor
 
-    agent = Agent.usingEndpointFactory(
-        reactor,
-        EndpointStringFactory(reactor, config.api_client_endpoint),
-    )
-    api_url = base_url.child(u'v1').child(u'magic-folder')
-    if include_secret_information:
-        api_url = api_url.replace(query=[(u"include_secret_information", u"1")])
-    headers = {
-        b"Authorization": u"Bearer {}".format(config.api_token).encode("ascii"),
-    }
-
-    # all this "access the HTTP API" stuff should be rolled into a
-    # class that all the subcommands can re-use .. just keeping it all
-    # here for now
-    class CannotAccessApiError(Exception):
-        """
-        The Magic Folder HTTP API can't be reached at all
-        """
-
-    try:
-        response = yield HTTPClient(agent).get(
-            api_url.to_uri().to_text().encode('ascii'),
-            headers=headers,
-        )
-    except ConnectError:
-        raise CannotAccessApiError(
-            "Can't reach the magic folder daemon at all on '{}'.".format(
-                config.api_client_endpoint,
-            )
-        )
-
-    if response.code != http.OK:
-        message = http.RESPONSES.get(response.code, b"Unknown Status")
-        raise Exception(
-            "Magic Folder API call received error response: {} ({})".format(
-                response.code, message)
-        )
-
-    result = yield readBody(response)
-    returnValue(json.loads(result))
+    client = create_magic_folder_client(reactor, config)
+    result = yield client.list_folders(include_secret_information)
+    returnValue(result)

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -9,7 +9,6 @@ import json
 
 from twisted.internet.defer import (
     inlineCallbacks,
-    returnValue,
 )
 
 from .client import (

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -50,7 +50,7 @@ def get_magic_folder_api_token_from_node_dir(node_directory):
     return config.get_private_config("api_auth_token")
 
 
-def get_magic_folder_api_base_url_config_dir(config_directory):
+def get_magic_folder_api_base_url_from_config_dir(config_directory):
     """
     :param str config_directory: a Magic Folder configuration directory.
 
@@ -91,7 +91,7 @@ def magic_folder_list(node_directory, config_directory=None):
     :return: JSON response from `GET /v1/magic-folder`.
     """
     if config_directory:
-        base_url = get_magic_folder_api_base_url_config_dir(config_directory)
+        base_url = get_magic_folder_api_base_url_from_config_dir(config_directory)
         api_token = get_magic_folder_api_token_from_config_dir(config_directory)
         api_url = base_url.child(u'v1').child(u'magic-folder')
     else:

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -17,11 +17,14 @@ from .client import (
 
 
 @inlineCallbacks
-def magic_folder_list(reactor, config, output, as_json=False, include_secret_information=False):
+def magic_folder_list(reactor, config, http_client, output, as_json=False, include_secret_information=False):
     """
     List folders associated with a node.
 
     :param GlobalConfigDatabase config: our configuration
+
+    :param HTTPClient http_client: a treq.HTTPClient instance we can
+        use to make API requests.
 
     :param output: a file-like object to which the output will be written
 
@@ -32,7 +35,7 @@ def magic_folder_list(reactor, config, output, as_json=False, include_secret_inf
 
     :return: JSON response from `GET /v1/magic-folder`.
     """
-    client = create_magic_folder_client(reactor, config)
+    client = create_magic_folder_client(reactor, config, http_client)
 
     mf_info = yield client.list_folders(include_secret_information)
 

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -48,6 +48,16 @@ def get_magic_folder_api_token_from_node_dir(node_directory):
     return config.get_private_config("api_auth_token")
 
 
+def get_magic_folder_api_base_url_config_dir(config_directory):
+    """
+    :param str config_directory: a Magic Folder configuration directory.
+
+    :returns: base URL for the given Magic Folder instance.
+    """
+    cfg = load_global_configuration(FilePath(config_directory))
+    return endpoint_description_to_http_api_root(cfg.api_endpoint)
+
+
 def get_magic_folder_api_token_from_config_dir(config_directory):
     """
     Get token stored in magic folder config directory.

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -21,6 +21,8 @@ from hyperlink import  DecodedURL
 from treq.client import HTTPClient
 from allmydata.client import read_config
 
+from .config import endpoint_description_to_http_api_root
+
 
 def get_magic_folder_api_base_url_from_node_dir(node_directory):
     """

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -6,106 +6,75 @@ Implements ```magic-folder list``` command.
 """
 
 import os
+import json
 
 from twisted.internet import reactor
 from twisted.internet.defer import (
     inlineCallbacks,
     returnValue,
 )
+from twisted.internet.endpoints import (
+    clientFromString,
+)
 from twisted.web.client import (
     Agent,
     readBody,
 )
 from twisted.web import http
+from twisted.web.iweb import (
+    IAgentEndpointFactory,
+)
 
 from hyperlink import  DecodedURL
 from treq.client import HTTPClient
 from allmydata.client import read_config
+from zope.interface import implementer
 
 from .config import endpoint_description_to_http_api_root
 
 
-def get_magic_folder_api_base_url_from_node_dir(node_directory):
+
+@implementer(IAgentEndpointFactory)
+class EndpointStringFactory(object):
     """
-    Get HTTP base URL stored in ``node_directory/magic-folder.url``.
-
-    :param str node_directory: A Tahoe node directory.
-
-    :returns: base URL for Magic Folder HTTP API.
+    Connect to a particular client endpoint-string
     """
-    magic_folder_url_file = os.path.join(node_directory, u"magic-folder.url")
-    with open(magic_folder_url_file, "r") as f:
-        magic_folder_url = f.read().strip()
-    return magic_folder_url
+    def __init__(self, reactor, endpoint_str):
+        self.reactor = reactor
+        self.endpoint = endpoint_str
 
-def get_magic_folder_api_token_from_node_dir(node_directory):
-    """
-    Get token stored in ```node_directory/private/api_auth_token```.
+    def endpointForURI(self, uri):
+        return clientFromString(self.reactor, self.endpoint)
 
-    :param str node_directory: a Tahoe node_directory.
-
-    :returns: an API auth token.
-    """
-    config = read_config(node_directory, u"")
-    return config.get_private_config("api_auth_token")
-
-
-def get_magic_folder_api_base_url_from_config_dir(config_directory):
-    """
-    :param str config_directory: a Magic Folder configuration directory.
-
-    :returns: base URL for the given Magic Folder instance.
-    """
-    from twisted.python.filepath import FilePath
-    from .config import load_global_configuration
-
-    cfg = load_global_configuration(FilePath(config_directory))
-    return endpoint_description_to_http_api_root(cfg.api_endpoint)
-
-
-def get_magic_folder_api_token_from_config_dir(config_directory):
-    """
-    Get token stored in magic folder config directory.
-
-    The token returned here does not authorize us.  I'm unsure why.
-
-    :param str config_directory: a Magic Folder configuration directory
-
-    :returns: an API auth token.
-    """
-    from twisted.python.filepath import FilePath
-    from .config import load_global_configuration
-
-    cfg = load_global_configuration(FilePath(config_directory))
-    return cfg.api_token
 
 
 @inlineCallbacks
-def magic_folder_list(node_directory, config_directory=None):
+def magic_folder_list(config, include_secret_information=False):
     """
     List folders associated with a node.
 
-    :param node_directory: a Tahoe node directory.
-    :param config_directory: a Magic Folder configuration directory.
+    :param GlobalConfigDatabase config: our configuration
+
+    :param bool include_secret_information: include sensitive private
+        information (such as long-term keys) if True (default: False).
 
     :return: JSON response from `GET /v1/magic-folder`.
     """
-    if config_directory:
-        base_url = get_magic_folder_api_base_url_from_config_dir(config_directory)
-        api_token = get_magic_folder_api_token_from_config_dir(config_directory)
-        api_url = base_url.child(u'v1').child(u'magic-folder')
-    else:
-        base_url = get_magic_folder_api_base_url_from_node_dir(node_directory)
-        api_token = get_magic_folder_api_token_from_node_dir(node_directory)
-        api_url = DecodedURL.from_text(
-            unicode(base_url, 'utf-8')
-        ).child(u'v1').child(u'magic-folder')
+    base_url = DecodedURL.from_text(u"http://invalid./")
+    from twisted.internet import reactor
 
+    agent = Agent.usingEndpointFactory(
+        reactor,
+        EndpointStringFactory(reactor, config.api_client_endpoint),
+    )
+    api_url = base_url.child(u'v1').child(u'magic-folder')
+    if include_secret_information:
+        api_url = api_url.replace(query=[(u"include_secret_information", u"1")])
     headers = {
-        b"Authorization": u"Bearer {}".format(api_token).encode("ascii"),
+        b"Authorization": u"Bearer {}".format(config.api_token).encode("ascii"),
     }
 
-    response = yield HTTPClient(Agent(reactor)).get(
+    response = yield HTTPClient(agent).get(
         api_url.to_uri().to_text().encode('ascii'),
         headers=headers,
     )
@@ -118,5 +87,4 @@ def magic_folder_list(node_directory, config_directory=None):
         )
 
     result = yield readBody(response)
-
-    returnValue(result)
+    returnValue(json.loads(result))

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -1,0 +1,87 @@
+# Copyright 2020 Least Authority TFA GmbH
+# See COPYING for details.
+
+"""
+Implements ```magic-folder list``` command.
+"""
+
+import os
+
+from twisted.internet import reactor
+from twisted.internet.defer import (
+    inlineCallbacks,
+    returnValue,
+)
+from twisted.web.client import (
+    Agent,
+    readBody,
+)
+
+from hyperlink import  DecodedURL
+from treq.client import HTTPClient
+from allmydata.client import read_config
+
+
+def get_magic_folder_api_base_url(node_directory):
+    """
+    :param str node_directory: A Tahoe client directory
+
+    :returns: base URL for Magic Folder HTTP API, stored in
+        ``node_directory/magic-folder.url``.
+    """
+    magic_folder_url_file = os.path.join(node_directory, u"magic-folder.url")
+    with open(magic_folder_url_file, "r") as f:
+        magic_folder_url = f.read().strip()
+    return magic_folder_url
+
+
+def get_magic_folder_api_token_from_cfg(config_directory):
+    """
+    Return token stored in magic folder config directory.
+
+    The token returned here does not authorize us.  I'm unsure why.
+    """
+    from twisted.python.filepath import FilePath
+    from .config import load_global_configuration
+
+    path = FilePath(config_directory)
+    return load_global_configuration(path).api_token
+
+
+def get_magic_folder_api_token(node_directory):
+    """
+    Return token stored in ```node_directory/private/api_auth_token```.
+    """
+    config = read_config(node_directory, u"")
+    return config.get_private_config("api_auth_token")
+
+
+@inlineCallbacks
+def magic_folder_list(node_directory):
+    """
+    List folders associated with a node.
+
+    :param options: TODO
+
+    :return: TODO JSON response from `/v1/magic-folder`.
+    """
+    base_url = get_magic_folder_api_base_url(node_directory)
+
+    api_url = DecodedURL.from_text(
+        unicode(base_url, 'utf-8')
+    ).child(u'v1').child(u'magic-folder')
+
+    api_token = get_magic_folder_api_token(node_directory)
+
+    headers = {
+        b"Authorization": u"Bearer {}".format(api_token).encode("ascii"),
+    }
+
+    response = yield HTTPClient(Agent(reactor)).get(
+        api_url.to_uri().to_text().encode('ascii'),
+        headers=headers,
+    )
+
+    result = yield readBody(response)
+
+    returnValue(result)

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -16,6 +16,7 @@ from twisted.web.client import (
     Agent,
     readBody,
 )
+from twisted.web import http
 
 from hyperlink import  DecodedURL
 from treq.client import HTTPClient
@@ -92,13 +93,13 @@ def magic_folder_list(node_directory, config_directory=None):
     if config_directory:
         base_url = get_magic_folder_api_base_url_config_dir(config_directory)
         api_token = get_magic_folder_api_token_from_config_dir(config_directory)
+        api_url = base_url.child(u'v1').child(u'magic-folder')
     else:
         base_url = get_magic_folder_api_base_url_from_node_dir(node_directory)
         api_token = get_magic_folder_api_token_from_node_dir(node_directory)
-
-    api_url = DecodedURL.from_text(
-        unicode(base_url, 'utf-8')
-    ).child(u'v1').child(u'magic-folder')
+        api_url = DecodedURL.from_text(
+            unicode(base_url, 'utf-8')
+        ).child(u'v1').child(u'magic-folder')
 
     headers = {
         b"Authorization": u"Bearer {}".format(api_token).encode("ascii"),
@@ -108,6 +109,13 @@ def magic_folder_list(node_directory, config_directory=None):
         api_url.to_uri().to_text().encode('ascii'),
         headers=headers,
     )
+
+    if response.code != http.OK:
+        message = http.RESPONSES.get(response.code, b"Unknown Status")
+        raise Exception(
+            "Magic Folder API call received error response: {} ({})".format(
+                response.code, message)
+        )
 
     result = yield readBody(response)
 

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -24,12 +24,11 @@ from allmydata.client import read_config
 
 def get_magic_folder_api_base_url_from_node_dir(node_directory):
     """
-    Get HTTP base URL.
+    Get HTTP base URL stored in ``node_directory/magic-folder.url``.
 
     :param str node_directory: A Tahoe node directory.
 
-    :returns: base URL for Magic Folder HTTP API, stored in
-        ``node_directory/magic-folder.url``.
+    :returns: base URL for Magic Folder HTTP API.
     """
     magic_folder_url_file = os.path.join(node_directory, u"magic-folder.url")
     with open(magic_folder_url_file, "r") as f:
@@ -54,6 +53,9 @@ def get_magic_folder_api_base_url_config_dir(config_directory):
 
     :returns: base URL for the given Magic Folder instance.
     """
+    from twisted.python.filepath import FilePath
+    from .config import load_global_configuration
+
     cfg = load_global_configuration(FilePath(config_directory))
     return endpoint_description_to_http_api_root(cfg.api_endpoint)
 
@@ -71,8 +73,8 @@ def get_magic_folder_api_token_from_config_dir(config_directory):
     from twisted.python.filepath import FilePath
     from .config import load_global_configuration
 
-    path = FilePath(config_directory)
-    return load_global_configuration(path).api_token
+    cfg = load_global_configuration(FilePath(config_directory))
+    return cfg.api_token
 
 
 @inlineCallbacks

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -38,7 +38,6 @@ def magic_folder_list(config, output, as_json=False, include_secret_information=
     client = create_magic_folder_client(reactor, config)
 
     mf_info = yield client.list_folders(include_secret_information)
-    mf_info = mf_info["folders"]
 
     if as_json:
         output.write(u"{}\n".format(json.dumps(mf_info, indent=4)))
@@ -71,8 +70,8 @@ def _list_human(info, output, include_secrets):
 
     if info:
         output.write(u"Configured magic-folders:\n")
-        for details in info:
-            output.write(u"{}:\n".format(details["name"]))
+        for name, details in info.items():
+            output.write(u"{}:\n".format(name))
             output.write(template.format(**details))
     else:
-        output.write("No magic-folders")
+        output.write(u"No magic-folders")

--- a/src/magic_folder/list.py
+++ b/src/magic_folder/list.py
@@ -17,7 +17,7 @@ from .client import (
 
 
 @inlineCallbacks
-def magic_folder_list(config, output, as_json=False, include_secret_information=False):
+def magic_folder_list(reactor, config, output, as_json=False, include_secret_information=False):
     """
     List folders associated with a node.
 
@@ -32,8 +32,6 @@ def magic_folder_list(config, output, as_json=False, include_secret_information=
 
     :return: JSON response from `GET /v1/magic-folder`.
     """
-    from twisted.internet import reactor
-
     client = create_magic_folder_client(reactor, config)
 
     mf_info = yield client.list_folders(include_secret_information)

--- a/src/magic_folder/test/cli/common.py
+++ b/src/magic_folder/test/cli/common.py
@@ -63,7 +63,6 @@ def cli(config_directory, argv):
     try:
         try:
             options.parseOptions([
-                b"--debug",
                 b"--config",
                 config_directory.asBytesMode().path,
             ] + argv)

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -140,7 +140,7 @@ class ListMagicFolder(AsyncTestCase):
         folder_path = FilePath(self.mktemp())
         folder_path.makedirs()
 
-        mf_config = self.config.create_magic_folder(
+        self.config.create_magic_folder(
             u"list-some-folder",
             folder_path,
             folder_path.child(u".state"),
@@ -164,7 +164,7 @@ class ListMagicFolder(AsyncTestCase):
         folder_path = FilePath(self.mktemp())
         folder_path.makedirs()
 
-        mf_config = self.config.create_magic_folder(
+        self.config.create_magic_folder(
             u"list-some-json-folder",
             folder_path,
             folder_path.child(u".state"),

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -111,7 +111,7 @@ class ListMagicFolder(AsyncTestCase):
         reports this.
         """
         output = StringIO()
-        yield magic_folder_list(self.config, output)
+        yield magic_folder_list(reactor, self.config, output)
         self.assertThat(
             output.getvalue(),
             Contains(u"No magic-folders")
@@ -124,7 +124,7 @@ class ListMagicFolder(AsyncTestCase):
         reports this in JSON format if given ``--json``.
         """
         output = StringIO()
-        yield magic_folder_list(self.config, output, as_json=True)
+        yield magic_folder_list(reactor, self.config, output, as_json=True)
         self.assertThat(
             output.getvalue(),
             AfterPreprocessing(json.loads, Equals({}))
@@ -150,7 +150,7 @@ class ListMagicFolder(AsyncTestCase):
         )
 
         output = StringIO()
-        yield magic_folder_list(self.config, output)
+        yield magic_folder_list(reactor, self.config, output)
         self.expectThat(output.getvalue(), Contains(u"list-some-folder"))
         self.expectThat(output.getvalue(), Contains(folder_path.path))
 
@@ -174,7 +174,7 @@ class ListMagicFolder(AsyncTestCase):
         )
 
         output = StringIO()
-        yield magic_folder_list(self.config, output, as_json=True, include_secret_information=True)
+        yield magic_folder_list(reactor, self.config, output, as_json=True, include_secret_information=True)
 
         self.expectThat(
             output.getvalue(),

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -1,5 +1,8 @@
 import json
 import os.path
+from io import (
+    StringIO,
+)
 
 from testtools import (
     ExpectedException,
@@ -32,10 +35,17 @@ from ...initialize import (
 )
 from ...config import (
     create_global_configuration,
+    create_testing_configuration,
     load_global_configuration,
 )
 from ...endpoints import (
     CannotConvertEndpointError,
+)
+from ...snapshot import (
+    create_local_author,
+)
+from ...list import (
+    magic_folder_list,
 )
 
 from ..common_util import (
@@ -71,7 +81,29 @@ class ListMagicFolder(AsyncTestCase):
         self.tempdir = self.client_fixture.tempdir
         self.node_directory = self.client_fixture.node_directory
         self.config_dir = FilePath(self.mktemp())
-        create_global_configuration(self.config_dir, u"tcp:4321", self.node_directory, u"tcp:localhost:4321")
+
+        # the Web APIs need a reference to a "global_service" .. which
+        # is cli.MagicFolderService (a MultiService in fact). It
+        # doesn't declare an interface, but only uses
+        # "get_folder_service(folder_name)" .. so we'll duck-type it
+        # instead
+
+        # inside create_testing_configuration, the GlobalService is
+        # hooked up to an in-process HTTP API root which is
+        # interrogated for information. So, we want to control which
+        # magic-folders it sees
+
+        self.magic_folders = {}
+
+        class GlobalService(object):
+            def get_folder_service(s, name):
+                return self.magic_folders[name]
+
+        self.config = create_testing_configuration(
+            self.config_dir,
+            self.node_directory,
+            GlobalService(),
+        )
 
     @defer.inlineCallbacks
     def test_list_none(self):
@@ -79,11 +111,12 @@ class ListMagicFolder(AsyncTestCase):
         When there are no Magic Folders at all, the output of the list command
         reports this.
         """
-        outcome = yield cli(
-            self.config_dir,
-            [b"list"],
+        output = StringIO()
+        yield magic_folder_list(self.config, output)
+        self.assertThat(
+            output.getvalue(),
+            Contains(u"No magic-folders")
         )
-        self.assertThat(outcome.stdout, Contains(u"No magic-folders"))
 
     @defer.inlineCallbacks
     def test_list_none_json(self):
@@ -91,11 +124,12 @@ class ListMagicFolder(AsyncTestCase):
         When there are no Magic Folders at all, the output of the list command
         reports this in JSON format if given ``--json``.
         """
-        outcome = yield cli(
-            self.config_dir,
-            [b"list", b"--json"],
+        output = StringIO()
+        yield magic_folder_list(self.config, output, as_json=True)
+        self.assertThat(
+            output.getvalue(),
+            AfterPreprocessing(json.loads, Equals({}))
         )
-        self.assertThat(outcome.stdout, AfterPreprocessing(json.loads, Equals({})))
 
     @defer.inlineCallbacks
     def test_list_some(self):
@@ -103,29 +137,23 @@ class ListMagicFolder(AsyncTestCase):
         When there are Magic Folders, the output of the list command describes
         them.
         """
-        # Get a magic folder.
-        folder_path = self.tempdir.child(u"magic-folder")
+        folder_path = FilePath(self.mktemp())
         folder_path.makedirs()
 
-        outcome = yield cli(
-            self.config_dir, [
-                b"add",
-                b"--name", b"list-some-folder",
-                b"--author", b"alice",
-                folder_path.asBytesMode().path,
-            ],
-        )
-        self.assertThat(
-            outcome.succeeded(),
-            Equals(True),
+        mf_config = self.config.create_magic_folder(
+            u"list-some-folder",
+            folder_path,
+            folder_path.child(u".state"),
+            create_local_author(u"alice"),
+            u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
+            u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
+            1,
         )
 
-        outcome = yield cli(
-            self.config_dir,
-            [b"list"],
-        )
-        self.expectThat(outcome.stdout, Contains(b"list-some-folder"))
-        self.expectThat(outcome.stdout, Contains(folder_path.path))
+        output = StringIO()
+        yield magic_folder_list(self.config, output)
+        self.expectThat(output.getvalue(), Contains(b"list-some-folder"))
+        self.expectThat(output.getvalue(), Contains(folder_path.path))
 
     @defer.inlineCallbacks
     def test_list_some_json(self):
@@ -133,35 +161,31 @@ class ListMagicFolder(AsyncTestCase):
         When there are Magic Folders, the output of the list command describes
         them in JSON format if given ``--json``.
         """
-        # Get a magic folder.
-        folder_path = self.tempdir.child(u"magic-folder")
+        folder_path = FilePath(self.mktemp())
         folder_path.makedirs()
 
-        outcome = yield cli(
-            self.config_dir, [
-                b"add",
-                b"--author", b"test",
-                b"--name", b"list-some-json-folder",
-                folder_path.asBytesMode().path,
-            ],
+        mf_config = self.config.create_magic_folder(
+            u"list-some-json-folder",
+            folder_path,
+            folder_path.child(u".state"),
+            create_local_author(u"alice"),
+            u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
+            u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
+            1,
         )
-        self.assertThat(
-            outcome.succeeded(),
-            Equals(True),
-        )
-        outcome = yield cli(
-            self.config_dir,
-            [b"list", b"--json", b"--include-secret-information"],
-        )
+
+        output = StringIO()
+        yield magic_folder_list(self.config, output, as_json=True, include_secret_information=True)
+
         self.expectThat(
-            outcome.stdout,
+            output.getvalue(),
             AfterPreprocessing(
                 json.loads,
                 ContainsDict({
                     u"list-some-json-folder": ContainsDict({
                         u"magic_path": Equals(folder_path.path),
-                        u"poll_interval": Equals(60),
-                        u"is_admin": Equals(True),
+                        u"poll_interval": Equals(1),
+                        u"is_admin": Equals(False),
                         u"collective_dircap": Always(),
                         u"upload_dircap": Always(),
                     }),

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -151,7 +151,7 @@ class ListMagicFolder(AsyncTestCase):
 
         output = StringIO()
         yield magic_folder_list(self.config, output)
-        self.expectThat(output.getvalue(), Contains(b"list-some-folder"))
+        self.expectThat(output.getvalue(), Contains(u"list-some-folder"))
         self.expectThat(output.getvalue(), Contains(folder_path.path))
 
     @defer.inlineCallbacks

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -80,7 +80,6 @@ class ListMagicFolder(AsyncTestCase):
 
         self.tempdir = self.client_fixture.tempdir
         self.node_directory = self.client_fixture.node_directory
-        self.config_dir = FilePath(self.mktemp())
 
         # the Web APIs need a reference to a "global_service" .. which
         # is cli.MagicFolderService (a MultiService in fact). It
@@ -100,7 +99,7 @@ class ListMagicFolder(AsyncTestCase):
                 return self.magic_folders[name]
 
         self.config = create_testing_configuration(
-            self.config_dir,
+            FilePath(self.mktemp()),
             self.node_directory,
             GlobalService(),
         )
@@ -313,10 +312,10 @@ class CreateMagicFolder(AsyncTestCase):
                 magic_folder.asBytesMode().path,
             ],
         )
-
         self.assertThat(
             outcome.succeeded(),
             Equals(True),
+            str(outcome),
         )
 
         outcome = yield cli(

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -14,8 +14,6 @@ from json import (
     loads,
 )
 
-import attr
-
 from hyperlink import (
     DecodedURL,
 )
@@ -47,9 +45,6 @@ from testtools.twistedsupport import (
     has_no_result,
 )
 
-from twisted.python.filepath import (
-    FilePath,
-)
 from twisted.web.http import (
     OK,
     CREATED,
@@ -108,9 +103,6 @@ from ..web import (
 )
 from ..config import (
     create_global_configuration,
-)
-from ..snapshot import (
-    create_local_author,
 )
 from .strategies import (
     local_authors,

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -457,7 +457,7 @@ class ListMagicFolderTests(SyncTestCase):
                                     u"is_admin": config.is_admin(),
                                 }
                                 for name, config
-                                in sorted(configs.items())
+                                in sorted(folders.items())
                             ),
                         }),
                     )

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -103,6 +103,7 @@ from ..web import (
 )
 from ..config import (
     create_global_configuration,
+    load_global_configuration,
 )
 from .strategies import (
     local_authors,
@@ -413,9 +414,10 @@ class ListMagicFolderTests(SyncTestCase):
             path_b = path_u.asBytesMode("utf-8")
             path_b.makedirs(ignoreExistingDirectory=True)
 
+        basedir = FilePath(self.mktemp())
         treq = treq_for_folders(
             object(),
-            FilePath(self.mktemp()),
+            basedir,
             AUTH_TOKEN,
             {
                 name: magic_folder_config(self.author, FilePath(self.mktemp()), path_u)
@@ -424,6 +426,12 @@ class ListMagicFolderTests(SyncTestCase):
             },
             False,
         )
+
+        config = load_global_configuration(basedir)
+        expected_folders = {
+            name: config.get_magic_folder(name)
+            for name in config.list_magic_folders()
+        }
 
         self.assertThat(
             authorized_request(treq, AUTH_TOKEN, b"GET", self.encoded_url),
@@ -448,7 +456,7 @@ class ListMagicFolderTests(SyncTestCase):
                                 u"is_admin": config.is_admin(),
                             }
                             for name, config
-                            in sorted(folders.items())
+                            in expected_folders.items()
                         }),
                     ),
                 ),

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -98,12 +98,14 @@ from ..cli import (
     MagicFolderService,
 )
 from ..web import (
-    APIv1,
     magic_folder_resource,
 )
 from ..config import (
     create_global_configuration,
     load_global_configuration,
+)
+from ..client import (
+    create_testing_http_client,
 )
 from .strategies import (
     local_authors,
@@ -339,9 +341,7 @@ def treq_for_folders(reactor, basedir, auth_token, folders, start_folder_service
         for name in folders:
             global_service.get_folder_service(name).startService()
 
-    v1_resource = APIv1(global_config, global_service)
-    root = magic_folder_resource(lambda: auth_token, v1_resource)
-    return StubTreq(root)
+    return create_testing_http_client(reactor, global_config, global_service, lambda: auth_token)
 
 
 def magic_folder_config(author, state_path, local_directory):

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -427,6 +427,7 @@ class ListMagicFolderTests(SyncTestCase):
             False,
         )
 
+        # note that treq_for_folders() will end up creating a configuration here
         config = load_global_configuration(basedir)
         expected_folders = {
             name: config.get_magic_folder(name)

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -436,23 +436,21 @@ class ListMagicFolderTests(SyncTestCase):
                     body_matcher=AfterPreprocessing(
                         loads,
                         Equals({
-                            u"folders": list(
-                                {
-                                    u"name": name,
-                                    u"author": {
-                                        u"name": config.author.name,
-                                        u"verify_key": config.author.verify_key.encode(Base32Encoder),
-                                    },
-                                    u"magic_path": config.magic_path.path,
-                                    u"stash_path": config.stash_path.path,
-                                    u"poll_interval": config.poll_interval,
-                                    u"is_admin": config.is_admin(),
-                                }
-                                for name, config
-                                in sorted(folders.items())
-                            ),
+                            name: {
+                                u"name": name,
+                                u"author": {
+                                    u"name": config.author.name,
+                                    u"verify_key": config.author.verify_key.encode(Base32Encoder),
+                                },
+                                u"magic_path": config.magic_path.path,
+                                u"stash_path": config.stash_path.path,
+                                u"poll_interval": config.poll_interval,
+                                u"is_admin": config.is_admin(),
+                            }
+                            for name, config
+                            in sorted(folders.items())
                         }),
-                    )
+                    ),
                 ),
             ),
         )

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -128,7 +128,7 @@ class MagicFolderAPIv1(Resource, object):
         Render a list of Magic Folders and some of their details, encoded as JSON.
         """
         request.responseHeaders.setRawHeaders(u"content-type", [u"application/json"])
-        include_secret_information = False
+        include_secret_information = int(request.args.get("include_secret_information", [0])[0])
 
         def get_folder_info(name, mf):
             info = {

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -317,8 +317,8 @@ class MagicFolderAPIv1(Resource, object):
         """
         Render a list of Magic Folders and some of their details, encoded as JSON.
         """
-        _application_json(request)  # set reply headers
         include_secret_information = int(request.args.get("include_secret_information", [0])[0])
+        _application_json(request)  # set reply headers
 
         def get_folder_info(name, mf):
             info = {

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -343,11 +343,9 @@ class MagicFolderAPIv1(Resource, object):
                 yield (name, self._global_config.get_magic_folder(name))
 
         return json.dumps({
-            u"folders": list(
-                get_folder_info(name, config)
-                for name, config
-                in all_folder_configs()
-            ),
+            name: get_folder_info(name, config)
+            for name, config
+            in all_folder_configs()
         })
 
 

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -334,8 +334,8 @@ class MagicFolderAPIv1(Resource, object):
             }
             if include_secret_information:
                 info[u"author"][u"signing_key"] = mf.author.signing_key.encode(Base32Encoder)
-                info[u"collective_dircap"] = mf.collective_dircap.encode("ascii")
-                info[u"upload_dircap"] = mf.upload_dircap.encode("ascii")
+                info[u"collective_dircap"] = mf.collective_dircap
+                info[u"upload_dircap"] = mf.upload_dircap
             return info
 
         def all_folder_configs():

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -338,11 +338,15 @@ class MagicFolderAPIv1(Resource, object):
                 info[u"upload_dircap"] = mf.upload_dircap.encode("ascii")
             return info
 
+        def all_folder_configs():
+            for name in sorted(self._global_config.list_magic_folders()):
+                yield (name, self._global_config.get_magic_folder(name))
+
         return json.dumps({
             u"folders": list(
                 get_folder_info(name, config)
-                for (name, config)
-                in sorted(self._magic_folder_state.iter_magic_folder_configs())
+                for name, config
+                in all_folder_configs()
             ),
         })
 


### PR DESCRIPTION
Fixes #207 

This makes "magic-folder list" use the HTTP API (instead of reading the config itself). To do so requires a "magic-folder HTTP API client", which is included in this (using the new "client api endpoint" config).

To facilitate testing, the configuration abstractions are changed to construct more things in-memory and to hook up an in-process HTTP treq client to the HTTP API. This piece introduces a "token provider" so that API tokens can be in-memory only as well.

Some of the integration tests/infrastructure needed a little adjustment too.