### PR TITLE
305.crypto deprecation warn

### DIFF
--- a/src/magic_folder/__init__.py
+++ b/src/magic_folder/__init__.py
@@ -2,7 +2,7 @@
 
 # see https://github.com/LeastAuthority/magic-folder/issues/305
 import warnings
-warnings.filterwarnings("ignore", module="OpenSSL.crypto.*", lineno=14)
+warnings.filterwarnings("ignore", message=".*Python 2 is no longer supported by the Python core team.*")
 
 __all__ = [
     "__version__",

--- a/src/magic_folder/__init__.py
+++ b/src/magic_folder/__init__.py
@@ -1,5 +1,9 @@
 # Copyright (C) Least Authority TFA GmbH
 
+# see https://github.com/LeastAuthority/magic-folder/issues/305
+import warnings
+warnings.filterwarnings("ignore", module="OpenSSL.crypto.*", lineno=14)
+
 __all__ = [
     "__version__",
 ]


### PR DESCRIPTION
Ignore warnings about python2.7 from `OpenSSL` (via `cryptography`).

fixes #305