### PR TITLE
Pin watchdog at a version before 0.10.4.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,9 @@ setup(name="magic_folder",
       install_requires=install_requires,
       extras_require={
           # For magic-folder on "darwin" (macOS) and the BSDs
-          ':sys_platform!="win32" and sys_platform!="linux2"': ["watchdog"],
+          # Pin to < 0.10.4 to fix tests.
+          # See https://github.com/LeastAuthority/magic-folder/issues/345
+          ':sys_platform!="win32" and sys_platform!="linux2"': ["watchdog<0.10.4"],
           "test": [
               # Pin a specific pyflakes so we don't have different folks
               # disagreeing on what is or is not a lint issue.  We can bump


### PR DESCRIPTION
It looks like watchdog made a change to the exact events emitted on macOS,
in a way that cause our mapping to inotify-like flags + our tests to start failing.
I'm guessing this wasn't noticed, since we weren't running macOS tests on PRs.

This is probably due to https://github.com/gorakhargosh/watchdog/pull/680, but
I suspect the issue is that we are getting more events than we expect, and the
first one doesn't match the one we test for.

Since we aren't currently using this code, I'm going to pin to a version that
passes the tests, until we get around to using this code.