### PR TITLE
Update tested distro version to version not at EOL.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,14 @@ workflows:
       # Contexts are managed in the CircleCI web interface:
       #
       #  https://app.circleci.com/settings/organization/github/LeastAuthority/contexts
-      - "debian-9": &DOCKERHUB_CONTEXT
+      - "debian-10": &DOCKERHUB_CONTEXT
           context:
             - "dockerhub-auth"
 
-      - "debian-8":
+      - "debian-9":
           <<: *DOCKERHUB_CONTEXT
           requires:
-            - "debian-9"
+            - "debian-10"
 
       - "ubuntu-20.04":
           <<: *DOCKERHUB_CONTEXT
@@ -33,12 +33,12 @@ workflows:
           requires:
             - "ubuntu-20.04"
 
-      - "fedora-32":
+      - "fedora-34":
           <<: *DOCKERHUB_CONTEXT
-      - "fedora-31":
+      - "fedora-33":
           <<: *DOCKERHUB_CONTEXT
           requires:
-            - "fedora-32"
+            - "fedora-34"
 
       - "centos-8":
           <<: *DOCKERHUB_CONTEXT
@@ -66,7 +66,7 @@ workflows:
           requires:
             # If the unit test suite doesn't pass, don't bother running the
             # integration tests.
-            - "debian-9"
+            - "debian-10"
 
   images:
     # Build the Docker images used by the ci jobs.  This makes the ci jobs
@@ -136,10 +136,10 @@ jobs:
           command: |
             ~/.local/bin/tox -e codechecks
 
-  debian-9: &DEBIAN
+  debian-10: &DEBIAN
     docker:
       - auth: *DOCKERHUB_AUTH
-        image: "magicfolderci/debian:9"
+        image: "magicfolderci/debian:10"
         user: "nobody"
 
     environment: &UTF_8_ENVIRONMENT
@@ -213,11 +213,11 @@ jobs:
             /tmp/venv/bin/codecov
 
 
-  debian-8:
+  debian-9:
     <<: *DEBIAN
     docker:
       - auth: *DOCKERHUB_AUTH
-        image: "magicfolderci/debian:8"
+        image: "magicfolderci/debian:9"
         user: "nobody"
 
 
@@ -225,7 +225,7 @@ jobs:
     <<: *DEBIAN
     docker:
       - auth: *DOCKERHUB_AUTH
-        image: "magicfolderci/pypy:2.7-7.3.0-buster"
+        image: "magicfolderci/pypy:2.7-7.3.4-buster"
         user: "nobody"
 
     environment:
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - "checkout"
-      # DRY, YAML-style.  See the debian-9 steps.
+      # DRY, YAML-style.  See the debian-10 steps.
       - run: *SETUP_VIRTUALENV
       - run: *RUN_TESTS
 
@@ -317,19 +317,19 @@ jobs:
       - run: *SUBMIT_COVERAGE
 
 
-  fedora-31:
+  fedora-33:
     <<: *RHEL_DERIV
     docker:
       - auth: *DOCKERHUB_AUTH
-        image: "magicfolderci/fedora:31"
+        image: "magicfolderci/fedora:33"
         user: "nobody"
 
 
-  fedora-32:
+  fedora-34:
     <<: *RHEL_DERIV
     docker:
       - auth: *DOCKERHUB_AUTH
-        image: "magicfolderci/fedora:32"
+        image: "magicfolderci/fedora:34"
         user: "nobody"
 
 


### PR DESCRIPTION
Fedora 32 EOL is 2021-05-25.
Debian 8 LTS EOL was 2020-06-30.