### PR TITLE
same health-check ignoring for all profiles

### DIFF
--- a/src/magic_folder/test/__init__.py
+++ b/src/magic_folder/test/__init__.py
@@ -62,6 +62,11 @@ def _configure_hypothesis():
     settings.register_profile(
         "magic-folder-fast",
         max_examples=1,
+        # see magic-folder-ci profile below for justification
+        suppress_health_check=[
+            HealthCheck.too_slow,
+        ],
+        deadline=None,
     )
 
     settings.register_profile(


### PR DESCRIPTION
Moved from discussion on an unrelated PR. @tomprince notes, "My thinking is that we want magic-folder-fast to be fast, and if something is triggering this health check, it isn't fast."
