### PR TITLE
Store relative path names in snapshots.

### DIFF
--- a/src/magic_folder/magic_folder.py
+++ b/src/magic_folder/magic_folder.py
@@ -107,6 +107,7 @@ class MagicFolder(service.MultiService):
                     mf_config,
                     mf_config.author,
                     mf_config.stash_path,
+                    mf_config.magic_path,
                 ),
             ),
             uploader_service=UploaderService.from_config(

--- a/src/magic_folder/magicpath.py
+++ b/src/magic_folder/magicpath.py
@@ -30,19 +30,3 @@ def should_ignore_file(path_u):
         _assert(len(path_u) < len(oldpath_u), path_u=path_u, oldpath_u=oldpath_u)
 
     return False
-
-def mangle_path(p):
-    """
-    returns a unicode string given a FilePath (should be mangled
-    according to .. whatever rules magic-folder already uses?)
-
-    :param FilePath p: file path to be mangled
-
-    :returns unicode: mangled path
-    """
-    # XXX why DO we "mangle paths"? Could we just put the
-    # relative path for the name here instead? (that is,
-    # relative to the magic-folder base).
-
-    # how else to get the unicode version of this path?
-    return path2magic(p.asTextMode(encoding="utf-8").path)

--- a/src/magic_folder/snapshot.py
+++ b/src/magic_folder/snapshot.py
@@ -514,7 +514,7 @@ def create_snapshot(name, author, data_producer, snapshot_stash_dir, parents=Non
     # 1. create a temp-file in our stash area
     temp_file_fd, temp_file_name = mkstemp(
         prefix="snap",
-        dir=snapshot_stash_dir.path,
+        dir=snapshot_stash_dir.asBytesMode("utf-8").path,
     )
     try:
         # 2. stream data_producer into our temp-file

--- a/src/magic_folder/test/test_local_snapshot.py
+++ b/src/magic_folder/test/test_local_snapshot.py
@@ -68,11 +68,10 @@ class MemorySnapshotCreator(object):
     """
     processed = attr.ib(default=attr.Factory(list))
 
-    def store_local_snapshot(self, path, relpath):
+    def store_local_snapshot(self, path):
         Message.log(
             message_type=u"memory-snapshot-creator:store-local-snapshot",
             path=path.path,
-            relpath=relpath,
         )
         self.processed.append(path)
 
@@ -264,6 +263,7 @@ class LocalSnapshotCreatorTests(SyncTestCase):
             db=self.db,
             author=self.author,
             stash_dir=self.db.stash_path,
+            magic_dir=self.db.magic_path,
         )
 
     @given(lists(path_segments(), unique=True),
@@ -284,7 +284,7 @@ class LocalSnapshotCreatorTests(SyncTestCase):
 
         for (file, filename, _unused) in files:
             self.assertThat(
-                self.snapshot_creator.store_local_snapshot(file, filename),
+                self.snapshot_creator.store_local_snapshot(file),
                 succeeded(Always())
             )
 
@@ -310,7 +310,7 @@ class LocalSnapshotCreatorTests(SyncTestCase):
 
         # make sure the store_local_snapshot() succeeds
         self.assertThat(
-            self.snapshot_creator.store_local_snapshot(foo, filename),
+            self.snapshot_creator.store_local_snapshot(foo),
             succeeded(Always()),
         )
 
@@ -322,7 +322,7 @@ class LocalSnapshotCreatorTests(SyncTestCase):
 
         # make sure the second call succeeds as well
         self.assertThat(
-            self.snapshot_creator.store_local_snapshot(foo, filename),
+            self.snapshot_creator.store_local_snapshot(foo),
             succeeded(Always()),
         )
         stored_snapshot2 = self.db.get_local_snapshot(foo_magicname)

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -110,12 +110,12 @@ class MagicFolderServiceTests(SyncTestCase):
         ``MagicFolder.local_snapshot_service`` can be used to create a new local
         snapshot for a file in the folder.
         """
-        magic_path = FilePath(self.mktemp())
+        magic_path = FilePath(self.mktemp()).asTextMode("utf-8")
         magic_path.asBytesMode("utf-8").makedirs()
 
-        target_path = magic_path.preauthChild(relative_target_path).asBytesMode("utf-8")
+        target_path = magic_path.preauthChild(relative_target_path)
         target_path.asBytesMode("utf-8").parent().makedirs(ignoreExistingDirectory=True)
-        target_path.setContent(content)
+        target_path.asBytesMode("utf-8").setContent(content)
 
         local_snapshot_creator = MemorySnapshotCreator()
         local_snapshot_service = LocalSnapshotService(magic_path, local_snapshot_creator)
@@ -243,7 +243,7 @@ class MagicFolderFromConfigTests(SyncTestCase):
             ]),
         )
 
-        basedir = FilePath(self.mktemp())
+        basedir = FilePath(self.mktemp()).asTextMode("utf-8")
         global_config = create_global_configuration(
             basedir,
             u"tcp:-1",
@@ -255,9 +255,9 @@ class MagicFolderFromConfigTests(SyncTestCase):
         magic_path.asBytesMode("utf-8").makedirs()
 
         statedir = basedir.child(u"state")
-        state_path = statedir.asTextMode("utf-8").preauthChild(relative_state_path)
+        state_path = statedir.preauthChild(relative_state_path)
 
-        target_path = magic_path.asTextMode("utf-8").preauthChild(file_path)
+        target_path = magic_path.preauthChild(file_path)
         target_path.asBytesMode("utf-8").parent().makedirs(ignoreExistingDirectory=True)
         target_path.asBytesMode("utf-8").setContent(content)
 
@@ -321,7 +321,7 @@ class MagicFolderFromConfigTests(SyncTestCase):
 
         self.assertThat(
             children(),
-            ContainsDict({path2magic(target_path.path): Always()}),
+            ContainsDict({path2magic(file_path): Always()}),
             "Children dictionary {!r} did not contain expected path".format(
                 children,
             ),

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -13,7 +13,6 @@ from nacl.encoding import (
 )
 
 from twisted.python.filepath import (
-    FilePath,
     InsecurePath,
 )
 from twisted.internet.defer import (
@@ -414,18 +413,7 @@ def _list_all_folder_snapshots(folder_config):
         representing all snapshots for that file.
     """
     for snapshot_path in folder_config.get_all_localsnapshot_paths():
-        absolute_path = magic2path(snapshot_path)
-        if not absolute_path.startswith(folder_config.magic_path.path):
-            raise ValueError(
-                "Found path {!r} in local snapshot database for magic-folder {!r} "
-                "that is outside of local magic folder directory {!r}.".format(
-                    absolute_path,
-                    folder_config.name,
-                    folder_config.magic_path.path,
-                ),
-            )
-        relative_segments = FilePath(absolute_path).segmentsFrom(folder_config.magic_path)
-        relative_path = u"/".join(relative_segments)
+        relative_path = magic2path(snapshot_path)
         yield relative_path, _list_all_path_snapshots(folder_config, snapshot_path)
 
 


### PR DESCRIPTION
#364 without the `relpath` api changes