### PR TITLE
Restore Nix packaging & CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ workflows:
       - "centos-8":
           <<: *DOCKERHUB_CONTEXT
 
+      - "nixos-19.09":
+          <<: *DOCKERHUB_CONTEXT
+
       # Test against PyPy 2.7/7.3.0
       - "pypy2.7-7.3":
           <<: *DOCKERHUB_CONTEXT
@@ -333,6 +336,86 @@ jobs:
         image: "magicfolderci/fedora:34"
         user: "nobody"
 
+
+  nixos-19.09:
+    docker:
+      # Run in a highly Nix-capable environment.
+      - auth: *DOCKERHUB_AUTH
+        image: "nixorg/nix:circleci"
+
+    environment:
+      NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09-small.tar.gz"
+
+    steps:
+      - "checkout"
+
+      - restore_cache:
+          # Get all of Nix's state relating to the particular revision of
+          # nixpkgs we're using.  It will always be the same.  CircleCI
+          # artifacts and nixpkgs store objects are probably mostly hosted in
+          # the same place (S3) so there's not a lot of difference for
+          # anything that's pre-built.  For anything we end up building
+          # ourselves, though, this saves us all of the build time (less the
+          # download time).
+          #
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          name: "Restore Nix Store Paths"
+          keys:
+            # Construct cache keys that allow sharing as long as nixpkgs
+            # revision is unchanged.
+            #
+            # If nixpkgs changes then potentially a lot of cached packages for
+            # the base system will be invalidated so we may as well drop them
+            # and make a new cache with the new packages.
+            - magic_folder-nix-store-v1-19.09-small
+            - magic_folder-nix-store-v1-
+
+      - "run":
+          name: "Build and Test"
+          command: |
+            # CircleCI build environment looks like it has a zillion and a
+            # half cores.  Don't let Nix autodetect this high core count
+            # because it blows up memory usage and fails the test run.  Pick a
+            # number of cores that suites the build environment we're paying
+            # for (the free one!).
+            #
+            # Also, let it run more than one job at a time because we have to
+            # build a couple simple little dependencies that don't take
+            # advantage of multiple cores and we get a little speedup by doing
+            # them in parallel.
+            #
+            # Keep failed build intermediates so we can upload logs for failed
+            # runs as artifacts, too.
+            nix-build --keep-failed --cores 3 --max-jobs 2 nix/
+
+      - "run":
+          name: "Prepare logs for upload"
+          # They need to be moved to the right place always, whether tests
+          # passed or failed.
+          when: "always"
+          command: |
+            mkdir -p /tmp/artifacts/logs
+
+            # Let a glob expand to nothing if there are no matches.
+            shopt -s nullglob
+
+            # Copy any logs from a failed build we can find.  Note that in
+            # this CircleCI build context, the source directory is named
+            # "project" instead of magic-folder.
+            for p in /tmp/nix-build-*-magic-folder-*.drv-0/project/_trial_temp/*; do
+              out="/tmp/artifacts/logs/$(basename "$p")"
+              mkdir "$out"
+              cp "$p"/*.log "$out"
+            done
+
+      - store_artifacts:
+          path: "/tmp/artifacts/logs"
+
+      - save_cache:
+          name: "Cache Nix Store Paths"
+          key: magic_folder-nix-store-v1-19.09-small
+          paths:
+            - "/nix"
 
   build-image: &BUILD_IMAGE
     # This is a template for a job to build a Docker image that has as much of

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,19 @@
-# This is the main entrypoint for the Tahoe-LAFS derivation.
+# This is the main entrypoint for the magic-folder derivation.
 { pkgs ? import <nixpkgs> { } }:
-pkgs.python2.pkgs.callPackage ./magic-folder.nix {
-  tahoe-lafs = pkgs.python2.pkgs.callPackage ./tahoe-lafs.nix { };
-}
+let
+  pkgs' = pkgs.extend (import ./overlays.nix);
+  callPackage = pkgs'.python27Packages.callPackage;
+in
+  callPackage ./magic-folder.nix {
+    # klein is not packaged in nixos 19.09 so supply it here
+    klein = callPackage ./klein.nix {
+      # tubes is not packaged either, though other klein dependencies are
+      tubes = callPackage ./tubes.nix { };
+    };
+
+    # The packaged tahoe-lafs is an "application" rather than a library.  It's
+    # possible it would work if we could mangle it into a library but instead
+    # we'll just supply our own package based on the upstream Tahoe-LAFS nix
+    # expressions (which provide a library directly).
+    tahoe-lafs = callPackage ./tahoe-lafs.nix { };
+  }

--- a/nix/klein.nix
+++ b/nix/klein.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pythonPackages, tubes }:
+
+buildPythonPackage rec {
+  pname = "klein";
+  version = "20.6.0";
+
+  propagatedBuildInputs = with pythonPackages; [
+    incremental
+    zope_interface
+    six
+    attrs
+    werkzeug
+    twisted
+    enum34
+    typing
+    tubes
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6584b9cdff4959b9dcee95a1c1c20010f521a2a12c4ff3cdd8b903a9b0e993f6";
+  };
+}

--- a/nix/magic-folder.nix
+++ b/nix/magic-folder.nix
@@ -1,15 +1,16 @@
-{ lib, python, buildPythonPackage, tahoe-lafs, importlib-metadata, hypothesis, testtools, fixtures, git }:
+{ lib, python, buildPythonPackage, pythonPackages, tahoe-lafs, klein, git }:
 buildPythonPackage rec {
   pname = "magic-folder";
   version = "2020-02-05";
   src = ../.;
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with pythonPackages; [
     importlib-metadata
     tahoe-lafs
+    klein
   ];
 
-  checkInputs = [
+  checkInputs = with pythonPackages; [
     hypothesis
     testtools
     fixtures

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,17 @@
+self: super: {
+  python27 = super.python27.override {
+    packageOverrides = python-self: python-super: {
+      # The newest typing is incompatible with the packaged version of
+      # Hypothesis.  Upgrading Hypothesis is like pulling on a loose thread in
+      # a sweater.  I pulled it as far as pytest where I found there was no
+      # upgrade route because pytest has dropped Python 2 support.
+      # Fortunately, downgrading typing ends up being fairly straightforward.
+      #
+      # For now.  This is, no doubt, a sign of things to come for the Python 2
+      # ecosystem - the early stages of a slow, painful death by the thousand
+      # cuts of incompatibilities between libraries with no maintained Python
+      # 2 support.
+      typing = python-self.callPackage ./typing.nix { };
+    };
+  };
+}

--- a/nix/tubes.nix
+++ b/nix/tubes.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi, pythonPackages }:
+
+buildPythonPackage rec {
+  pname = "Tubes";
+  version = "0.2.0";
+
+  propagatedBuildInputs = with pythonPackages; [
+    six
+    characteristic
+    twisted
+  ];
+
+  doCheck = false;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:0sg1gg2002h1xsgxigznr1zk1skwmhss72dzk6iysb9k9kdgymcd";
+  };
+}

--- a/nix/typing.nix
+++ b/nix/typing.nix
@@ -1,0 +1,30 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy3k, isPyPy, python }:
+
+let
+  testDir = if isPy3k then "src" else "python2";
+
+in buildPythonPackage rec {
+  pname = "typing";
+  version = "3.6.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:0ba9acs4awx15bf9v3nrs781msbd2nx826906nj6fqks2bvca9s0";
+  };
+
+  # Error for Python3.6: ImportError: cannot import name 'ann_module'
+  # See https://github.com/python/typing/pull/280
+  # Also, don't bother on PyPy: AssertionError: TypeError not raised
+  doCheck = pythonOlder "3.6" && !isPyPy;
+
+  checkPhase = ''
+    cd ${testDir}
+    ${python.interpreter} -m unittest discover
+  '';
+
+  meta = with lib; {
+    description = "Backport of typing module to Python versions older than 3.5";
+    homepage = https://docs.python.org/3/library/typing.html;
+    license = licenses.psfl;
+  };
+}


### PR DESCRIPTION
Fixes #371 

Regarding:

> Note, I'm thinking about adding a dependency on jsonschema and pyyaml in the near future as well.

pyyaml is already a transitive dependency so it's no problem.  jsonschema seems to be fine too, as long as 2.6.0 is close enough.  If a newer jsonschema is required then ... :shrug: 

Here's the patch that does both of those things, for what it's worth

```diff
modified   nix/magic-folder.nix
@@ -8,6 +8,9 @@ buildPythonPackage rec {
     importlib-metadata
     tahoe-lafs
     klein
+
+    pyyaml
+    jsonschema
   ];

   checkInputs = with pythonPackages; [
```