### PR TITLE
Use `cryptography.hazmat.primitives.constant_time.bytes_eq` instead of `allmydata.util.hashutil.timing_safe_compare`.

### DIFF
--- a/newsfragments/336.minor
+++ b/newsfragments/336.minor
@@ -1,0 +1,1 @@
+Add your info here

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,9 @@ install_requires = [
     # We use them directly, rather than the re-exports from allmydata
     "pyutil >= 3.3.0",
 
+    # This is the version of cryptography required by tahoe-lafs
+    "cryptography >= 2.6",
+
     # last py2 release of klein
     "klein==20.6.0",
 ]

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -234,7 +234,7 @@ def tahoe_lafs_readonly_dir_capabilities():
 
 def tokens():
     """
-    Build byte strings which are usable as Tahoe-LAFS web API authentication
+    Build byte strings which are usable as magic-folder web API authentication
     tokens.
     """
     return binary(

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -53,9 +53,7 @@ from allmydata.uri import (
 from allmydata.interfaces import (
     IDirnodeURI,
 )
-from allmydata.util.hashutil import (
-    timing_safe_compare,
-)
+from cryptography.hazmat.primitives.constant_time import bytes_eq as timing_safe_compare
 
 from .status import (
     StatusFactory,
@@ -515,8 +513,13 @@ def _is_authorized(request, get_auth_token):
     if len(authorization) > 1:
         return False
     auth_token = get_auth_token()
-    expected = u"Bearer {}".format(auth_token).encode("ascii")
+    expected = b"Bearer %s" % (auth_token,)
+    # This ends up calling `hmac.compare_digest`. Looking at the source for
+    # that method suggests that it tries to make timing dependence for unequal
+    # length strings be on the second argument.
+    # Pass the attacker controlled value, to avoid leaking length information
+    # of the expected value.
     return timing_safe_compare(
-        authorization[0].encode("ascii"),
         expected,
+        authorization[0].encode("ascii"),
     )


### PR DESCRIPTION
Fixes #336. See #391.