### PR TITLE
Don't leave API support for configuring state-directory name for magic-folders.

### DIFF
--- a/newsfragments/398.minor
+++ b/newsfragments/398.minor
@@ -1,0 +1,1 @@
+Add your info here

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1251,14 +1251,14 @@ class GlobalConfigDatabase(object):
             )
             return config
 
-    def get_default_state_path(self, name):
+    def _get_state_path(self, name):
         """
         :param unicode name: the name of a magic-folder (doesn't have to
             exist yet)
 
-        :returns: a default directory-name to contain the state of a
-            magic-folder. This directory will not exist and will be
-            a sub-directory of the config location.
+        :returns: the directory-name to contain the state of a magic-folder.
+            This directory will not exist and will be a sub-directory of the
+            config location.
         """
         return self.basedir.child(name)
 
@@ -1305,7 +1305,7 @@ class GlobalConfigDatabase(object):
                 failed_cleanups.append((clean.path, e))
         return failed_cleanups
 
-    def create_magic_folder(self, name, magic_path, state_path, author,
+    def create_magic_folder(self, name, magic_path, author,
                             collective_dircap, upload_dircap, poll_interval):
         """
         Add a new Magic Folder configuration.
@@ -1314,9 +1314,6 @@ class GlobalConfigDatabase(object):
 
         :param FilePath magic_path: the synchronized directory which
             must already exist.
-
-        :param FilePath state_path: the configuration and state
-            directory (which should not already exist)
 
         :param LocalAuthor author: the signer of snapshots created in
             this folder
@@ -1340,9 +1337,10 @@ class GlobalConfigDatabase(object):
             raise ValueError(
                 "'{}' does not exist".format(magic_path.path)
             )
+        state_path = self._get_state_path(name).asTextMode("utf-8")
         if state_path.asBytesMode("utf-8").exists():
             raise ValueError(
-                "'{}' already exists".format(state_path.path)
+                "magic-folder state directory {}' already exists".format(state_path.path)
             )
 
         stash_path = state_path.child(u"stash").asTextMode("utf-8")

--- a/src/magic_folder/create.py
+++ b/src/magic_folder/create.py
@@ -69,17 +69,11 @@ def magic_folder_create(config, name, author_name, local_dir, poll_interval, tah
         entry_cap=personal_readonly_cap,
     )
 
-    # create our "state" directory for this magic-folder (could be
-    # configurable in the future)
-    state_dir = config.get_default_state_path(name)
     config.create_magic_folder(
         name,
         local_dir,
-        state_dir,
         author,
         collective_write_cap,
         personal_write_cap,
         poll_interval,
     )
-    # if the create fails, state_dir will be cleaned up already inside
-    # create_magic_folder()

--- a/src/magic_folder/migrate.py
+++ b/src/magic_folder/migrate.py
@@ -73,13 +73,11 @@ def magic_folder_migrate(config_dir, listen_endpoint_str, tahoe_node_directory, 
         tahoe_node_directory.child("private").child("magic_folders.yaml").open("r"),
     )
     for mf_name, mf_config in magic_folders['magic-folders'].items():
-        state_dir = config_dir.child(mf_name)
         author = create_local_author(author_name)
 
         config.create_magic_folder(
             mf_name,
             FilePath(mf_config[u'directory']),
-            state_dir,
             author,
             mf_config[u'collective_dircap'],
             mf_config[u'upload_dircap'],

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -178,7 +178,6 @@ class ListMagicFolder(AsyncTestCase):
         self.config.create_magic_folder(
             u"list-some-folder",
             folder_path,
-            folder_path.child(u".state"),
             create_local_author(u"alice"),
             u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
             u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
@@ -202,7 +201,6 @@ class ListMagicFolder(AsyncTestCase):
         self.config.create_magic_folder(
             u"list-some-json-folder",
             folder_path,
-            folder_path.child(u".state"),
             create_local_author(u"alice"),
             u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
             u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -98,7 +98,7 @@ FOLDER_ALPHABET = characters(
         # FIXME: https://github.com/LeastAuthority/magic-folder/issues/369
         "Cc",
     ),
-    blacklist_characters=(u"\x00", u"/"),
+    blacklist_characters=(u"\x00", u"/", u"\\"),
 )
 
 def _valid_path_segment(segment):
@@ -214,6 +214,9 @@ def folder_names():
     ).filter(
         # FIXME: https://github.com/LeastAuthority/magic-folder/issues/369
         _valid_path_segment
+    ).filter(
+        # FIXME: https://github.com/LeastAuthority/magic-folder/issues/369
+        lambda name: name not in (u".", u"..")
     )
 
 
@@ -245,6 +248,7 @@ def tahoe_lafs_dir_capabilities():
     return builds(
         lambda a, b: u"URI:DIR2:{}:{}".format(base32.b2a(a), base32.b2a(b)),
         binary(min_size=16, max_size=16),
+
         binary(min_size=32, max_size=32),
     )
 

--- a/src/magic_folder/test/test_api_cli.py
+++ b/src/magic_folder/test/test_api_cli.py
@@ -539,7 +539,6 @@ class TestDumpState(AsyncTestCase):
         magic_path.makedirs()
         config = self.global_config.create_magic_folder(
             name="test",
-            state_path=self.magic_config.child("test_stash"),
             magic_path=magic_path,
             author=author,
             collective_dircap="URI:DIR2:hz46fi2e7gy6i3h4zveznrdr5q:i7yc4dp33y4jzvpe5jlaqyjxq7ee7qj2scouolumrfa6c7prgkvq",

--- a/src/magic_folder/test/test_config.py
+++ b/src/magic_folder/test/test_config.py
@@ -229,7 +229,6 @@ class GlobalConfigDatabaseMagicFolderTests(SyncTestCase):
         magic_folder = config.create_magic_folder(
             u"foo",
             magic,
-            self.temp.child("state"),
             alice,
             u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
             u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
@@ -248,7 +247,6 @@ class GlobalConfigDatabaseMagicFolderTests(SyncTestCase):
         config.create_magic_folder(
             u"foo",
             magic,
-            self.temp.child("state"),
             alice,
             u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
             u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
@@ -258,7 +256,6 @@ class GlobalConfigDatabaseMagicFolderTests(SyncTestCase):
             config.create_magic_folder(
                 u"foo",
                 magic,
-                self.temp.child("state2"),
                 alice,
                 u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
                 u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
@@ -273,7 +270,6 @@ class GlobalConfigDatabaseMagicFolderTests(SyncTestCase):
             config.create_magic_folder(
                 u"foo",
                 magic,
-                self.temp.child("state"),
                 alice,
                 u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
                 u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
@@ -282,15 +278,15 @@ class GlobalConfigDatabaseMagicFolderTests(SyncTestCase):
 
     def test_folder_state_already_exists(self):
         config = create_global_configuration(self.temp, u"tcp:1234", self.node_dir, u"tcp:localhost:1234")
+        name = u"foo"
         alice = create_local_author(u"alice")
         magic = self.temp.child("magic")
-        state = self.temp.child("state")
+        state = config._get_state_path(name)
         magic.makedirs()
         state.makedirs()  # shouldn't pre-exist, though
         with ExpectedException(ValueError, ".*{}.*".format(escape(state.path))):
             config.create_magic_folder(
-                u"foo",
-                magic,
+                name,
                 state,
                 alice,
                 u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
@@ -303,14 +299,13 @@ class GlobalConfigDatabaseMagicFolderTests(SyncTestCase):
         we can retrieve the stash-path from a magic-folder-confgi
         """
         config = create_global_configuration(self.temp, u"tcp:1234", self.node_dir, u"tcp:localhost:1234")
+        name = u"foo"
         alice = create_local_author(u"alice")
         magic = self.temp.child("magic")
-        state = self.temp.child("state")
         magic.makedirs()
         config.create_magic_folder(
-            u"foo",
+            name,
             magic,
-            state,
             alice,
             u"URI:DIR2-RO:ou5wvazwlyzmqw7yof5ifmgmau:xqzt6uoulu4f3m627jtadpofnizjt3yoewzeitx47vw6memofeiq",
             u"URI:DIR2:bgksdpr3lr2gvlvhydxjo2izea:dfdkjc44gg23n3fxcxd6ywsqvuuqzo4nrtqncrjzqmh4pamag2ia",
@@ -320,7 +315,7 @@ class GlobalConfigDatabaseMagicFolderTests(SyncTestCase):
         mf_config = config.get_magic_folder(u"foo")
         self.assertThat(
             mf_config.stash_path,
-            Equals(state.child("stash"))
+            Equals(config._get_state_path(name).child(u"stash")),
         )
 
     def test_get_folder_nonexistent(self):

--- a/src/magic_folder/test/test_local_snapshot.py
+++ b/src/magic_folder/test/test_local_snapshot.py
@@ -261,7 +261,6 @@ class LocalSnapshotCreatorTests(SyncTestCase):
         self.db = self.global_db.create_magic_folder(
             u"some-folder",
             self.magic,
-            self.temp.child(u"state"),
             self.author,
             u"URI:DIR2-RO:aaa:bbb",
             u"URI:DIR2:ccc:ddd",

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -250,7 +250,7 @@ class MagicFolderFromConfigTests(SyncTestCase):
 
         basedir = FilePath(self.mktemp()).asTextMode("utf-8")
         global_config = create_global_configuration(
-            basedir,
+            basedir.child("config"),
             u"tcp:-1",
             FilePath(u"/non-tahoe-directory"),
             u"tcp:127.0.0.1:-1",
@@ -259,8 +259,6 @@ class MagicFolderFromConfigTests(SyncTestCase):
         magic_path = basedir.preauthChild(relative_magic_path)
         magic_path.asBytesMode("utf-8").makedirs()
 
-        state_path = basedir.child(u"state")
-
         target_path = magic_path.preauthChild(file_path)
         target_path.asBytesMode("utf-8").parent().makedirs(ignoreExistingDirectory=True)
         target_path.asBytesMode("utf-8").setContent(content)
@@ -268,7 +266,6 @@ class MagicFolderFromConfigTests(SyncTestCase):
         global_config.create_magic_folder(
             name,
             magic_path,
-            state_path,
             author,
             collective_dircap,
             upload_dircap,

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -312,7 +312,6 @@ def treq_for_folders(reactor, basedir, auth_token, folders, start_folder_service
         global_config.create_magic_folder(
             name,
             config[u"magic-path"],
-            config[u"state-path"],
             config[u"author"],
             config[u"collective-dircap"],
             config[u"upload-dircap"],
@@ -345,12 +344,11 @@ def treq_for_folders(reactor, basedir, auth_token, folders, start_folder_service
     return create_testing_http_client(reactor, global_config, global_service, lambda: auth_token, tahoe_client, WebSocketStatusService())
 
 
-def magic_folder_config(author, state_path, local_directory):
+def magic_folder_config(author, local_directory):
     # see also treq_for_folders() where these dicts are turned into
     # real magic-folder configs
     return {
         u"magic-path": local_directory,
-        u"state-path": state_path,
         u"author": author,
         u"collective-dircap": u"URI:DIR2-RO:{}:{}".format(b2a("\0" * 16), b2a("\1" * 32)),
         u"upload-dircap": u"URI:DIR2:{}:{}".format(b2a("\2" * 16), b2a("\3" * 32)),
@@ -420,7 +418,7 @@ class ListMagicFolderTests(SyncTestCase):
             basedir,
             AUTH_TOKEN,
             {
-                name: magic_folder_config(self.author, FilePath(self.mktemp()), path_u)
+                name: magic_folder_config(self.author, path_u)
                 for (name, path_u)
                 in folders.items()
             },
@@ -494,7 +492,7 @@ class CreateSnapshotTests(SyncTestCase):
             object(),
             FilePath(self.mktemp()),
             AUTH_TOKEN,
-            {folder_name: magic_folder_config(author, FilePath(self.mktemp()), local_path)},
+            {folder_name: magic_folder_config(author, local_path)},
             # The interesting behavior of this test hinges on this flag.  We
             # decline to start the folder services here.  Therefore, no local
             # snapshots will ever be created.  This lets us observe the
@@ -537,7 +535,7 @@ class CreateSnapshotTests(SyncTestCase):
             object(),
             FilePath(self.mktemp()),
             AUTH_TOKEN,
-            {folder_name: magic_folder_config(author, FilePath(self.mktemp()), local_path)},
+            {folder_name: magic_folder_config(author, local_path)},
             # This test carefully targets a failure mode that doesn't require
             # the service to be running.
             start_folder_services=False,
@@ -591,7 +589,7 @@ class CreateSnapshotTests(SyncTestCase):
             Clock(),
             FilePath(self.mktemp()),
             AUTH_TOKEN,
-            {folder_name: magic_folder_config(author, FilePath(self.mktemp()), local_path)},
+            {folder_name: magic_folder_config(author, local_path)},
             # Unlike test_wait_for_completion above we start the folder
             # services.  This will allow the local snapshot to be created and
             # our request to receive a response.
@@ -667,7 +665,7 @@ class CreateSnapshotTests(SyncTestCase):
             Clock(),
             FilePath(self.mktemp()),
             AUTH_TOKEN,
-            {folder_name: magic_folder_config(author, FilePath(self.mktemp()), local_path)},
+            {folder_name: magic_folder_config(author, local_path)},
             # Unlike test_wait_for_completion above we start the folder
             # services.  This will allow the local snapshot to be created and
             # our request to receive a response.
@@ -791,7 +789,6 @@ class ParticipantsTests(SyncTestCase):
 
         folder_config = magic_folder_config(
             create_local_author("iris"),
-            FilePath(self.mktemp()),
             local_path,
         )
         # we can't add a new participant if their DMD is the same as
@@ -889,7 +886,6 @@ class ParticipantsTests(SyncTestCase):
         local_path.makedirs()
         folder_config = magic_folder_config(
             create_local_author(author),
-            FilePath(self.mktemp()),
             local_path,
         )
 
@@ -952,7 +948,6 @@ class ParticipantsTests(SyncTestCase):
         local_path.makedirs()
         folder_config = magic_folder_config(
             create_local_author(author),
-            FilePath(self.mktemp()),
             local_path,
         )
 
@@ -1018,7 +1013,6 @@ class ParticipantsTests(SyncTestCase):
         local_path.makedirs()
         folder_config = magic_folder_config(
             create_local_author(author),
-            FilePath(self.mktemp()),
             local_path,
         )
 
@@ -1083,7 +1077,6 @@ class ParticipantsTests(SyncTestCase):
         local_path.makedirs()
         folder_config = magic_folder_config(
             create_local_author(author),
-            FilePath(self.mktemp()),
             local_path,
         )
 
@@ -1148,7 +1141,6 @@ class ParticipantsTests(SyncTestCase):
         local_path.makedirs()
         folder_config = magic_folder_config(
             create_local_author(author),
-            FilePath(self.mktemp()),
             local_path,
         )
 
@@ -1204,7 +1196,6 @@ class ParticipantsTests(SyncTestCase):
         local_path.makedirs()
         folder_config = magic_folder_config(
             create_local_author(author),
-            FilePath(self.mktemp()),
             local_path,
         )
 


### PR DESCRIPTION
To address #369, I'm changing the pathname to be constructed in a specific way
from the folder name. There is no reason for this internal directory name to
be configurable.