### PR TITLE
Remove tahoe windows fixups from magic-folder tests.

### DIFF
--- a/newsfragments/416.minor
+++ b/newsfragments/416.minor
@@ -1,0 +1,1 @@
+Add your info here

--- a/src/magic_folder/test/__init__.py
+++ b/src/magic_folder/test/__init__.py
@@ -91,11 +91,5 @@ def _configure_hypothesis():
     settings.load_profile(profile_name)
 _configure_hypothesis()
 
-
-import sys
-if sys.platform == "win32":
-    from allmydata.windows.fixups import initialize
-    initialize()
-
 from eliot import to_file
 to_file(open("eliot.log", "w"))


### PR DESCRIPTION
The fixups appear to do a few things:
- Call `SetErrorMode`[1]. This appears to be for errorhandling for `GetDiskFreeSpaceExW` in `allmydata.util.fileutil`.
- Various things for dealing with unicode output on the console.
- Handling unicode command-line arguments.

Given that we are only doing this in tests, I don't think any of those mater.

[1] https://docs.microsoft.com/en-ca/windows/win32/api/errhandlingapi/nf-errhandlingapi-seterrormode

See #391.