### PR TITLE
Add a way for business logic to throw an expcetion that is propagated to the API.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ jobs:
             #
             # Keep failed build intermediates so we can upload logs for failed
             # runs as artifacts, too.
-            nix-build --keep-failed --cores 3 --max-jobs 2 nix/
+            nix-build --show-trace --keep-failed --cores 3 --max-jobs 2 nix/
 
       - "run":
           name: "Prepare logs for upload"

--- a/newsfragments/430.minor
+++ b/newsfragments/430.minor
@@ -1,0 +1,1 @@
+Add your info here

--- a/nix/attrs.nix
+++ b/nix/attrs.nix
@@ -1,0 +1,14 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "attrs";
+  version = "19.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72";
+  };
+
+  # To prevent infinite recursion with pytest
+  doCheck = false;
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -3,6 +3,9 @@ self: super: {
     packageOverrides = self.lib.composeExtensions
       old.packageOverrides
       (python-self: python-super: rec {
+        attrs = python-self.callPackage ./attrs.nix { };
+        pytest = python-self.callPackage ./pytest.nix { };
+        pytest_4 = pytest;
         # The newest typing is incompatible with the packaged version of
         # Hypothesis.  Upgrading Hypothesis is like pulling on a loose thread in
         # a sweater.  I pulled it as far as pytest where I found there was no

--- a/nix/pytest.nix
+++ b/nix/pytest.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, attrs, py
+, setuptools_scm, setuptools, six, pluggy, funcsigs, more-itertools
+, atomicwrites, writeText, pathlib2, wcwidth, packaging
+}:
+buildPythonPackage rec {
+  version = "4.6.11";
+  pname = "pytest";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "50fa82392f2120cc3ec2ca0a75ee615be4c479e66669789771f1758332be4353";
+  };
+
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ attrs py setuptools six pluggy more-itertools atomicwrites wcwidth packaging funcsigs pathlib2 ];
+
+  # To prevent infinite recursion with hypothesis
+  doCheck = false;
+
+  # Remove .pytest_cache when using py.test in a Nix build
+  setupHook = writeText "pytest-hook" ''
+    pytestcachePhase() {
+        find $out -name .pytest_cache -type d -exec rm -rf {} +
+    }
+    preDistPhases+=" pytestcachePhase"
+  '';
+}

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -153,6 +153,14 @@ class BearerTokenAuthorization(Resource, object):
         # Don't let anything through that isn't authorized.
         return Unauthorized()
 
+def _load_json(body):
+    """
+    Load json from body, raising :py:`APIError` on failure.
+    """
+    try:
+        return json.loads(body)
+    except ValueError as e:
+        raise APIError.from_exception(http.BAD_REQUEST, e, prefix="Could not load JSON")
 
 @attr.s
 class APIv1(object):
@@ -272,41 +280,38 @@ class APIv1(object):
             returnValue(NoResource(b"{}"))
 
         body = request.content.read()
-        try:
-            participant = json.loads(body)
-            required_keys = {
-                "author",
-                "personal_dmd",
-            }
-            required_author_keys = {
-                "name",
-                # not yet
-                # "public_key_base32",
-            }
-            if set(participant.keys()) != required_keys:
-                raise _InputError("Require input: {}".format(", ".join(sorted(required_keys))))
-            if set(participant["author"].keys()) != required_author_keys:
-                raise _InputError("'author' requires: {}".format(", ".join(sorted(required_author_keys))))
+        participant = _load_json(body)
 
-            author = create_author(
-                participant["author"]["name"],
-                # we don't yet properly track keys but need one
-                # here .. this won't be correct, but we won't use
-                # it .. following code still only looks at the
-                # .name attribute
-                # see https://github.com/LeastAuthority/magic-folder/issues/331
-                VerifyKey(os.urandom(32)),
-            )
+        required_keys = {
+            "author",
+            "personal_dmd",
+        }
+        required_author_keys = {
+            "name",
+            # not yet
+            # "public_key_base32",
+        }
+        if set(participant.keys()) != required_keys:
+            raise _InputError("Require input: {}".format(", ".join(sorted(required_keys))))
+        if set(participant["author"].keys()) != required_author_keys:
+            raise _InputError("'author' requires: {}".format(", ".join(sorted(required_author_keys))))
 
-            dmd = tahoe_uri_from_string(participant["personal_dmd"])
-            if not IDirnodeURI.providedBy(dmd):
-                raise _InputError("personal_dmd must be a directory-capability")
-            if not dmd.is_readonly():
-                raise _InputError("personal_dmd must be read-only")
-            personal_dmd_cap = participant["personal_dmd"]
-        except _InputError as e:
-            request.setResponseCode(http.BAD_REQUEST)
-            returnValue(json.dumps({"reason": str(e)}))
+        author = create_author(
+            participant["author"]["name"],
+            # we don't yet properly track keys but need one
+            # here .. this won't be correct, but we won't use
+            # it .. following code still only looks at the
+            # .name attribute
+            # see https://github.com/LeastAuthority/magic-folder/issues/331
+            VerifyKey(os.urandom(32)),
+        )
+
+        dmd = tahoe_uri_from_string(participant["personal_dmd"])
+        if not IDirnodeURI.providedBy(dmd):
+            raise _InputError("personal_dmd must be a directory-capability")
+        if not dmd.is_readonly():
+            raise _InputError("personal_dmd must be read-only")
+        personal_dmd_cap = participant["personal_dmd"]
 
         collective = participants_from_collective(
             folder_config.collective_dircap,
@@ -404,11 +409,13 @@ class APIv1(object):
         })
 
 
-class _InputError(ValueError):
+class _InputError(APIError):
     """
     Local errors with our input validation to report back to HTTP
     clients.
     """
+    def __init__(self, reason):
+        super(_InputError, self).__init__(code=http.BAD_REQUEST, reason=reason)
 
 def _application_json(request):
     request.responseHeaders.setRawHeaders(u"content-type", [u"application/json"])

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -61,6 +61,7 @@ from allmydata.interfaces import (
 )
 from cryptography.hazmat.primitives.constant_time import bytes_eq as timing_safe_compare
 
+from .common import APIError
 from .status import (
     StatusFactory,
     IStatus,
@@ -167,6 +168,13 @@ class APIv1(object):
     _tahoe_client = attr.ib()
 
     app = Klein()
+
+    @app.handle_errors(APIError)
+    def handle_api_error(self, request, failure):
+        exc = failure.value
+        request.setResponseCode(exc.code or http.INTERNAL_SERVER_ERROR)
+        _application_json(request)
+        return json.dumps({"reason": exc.reason})
 
     @app.handle_errors(RequestRedirect)
     def handle_redirect(self, request, failure):


### PR DESCRIPTION
This is a followup to #405, which allows code to throw errors that are passed to users.