### PR TITLE
per-folder status information

### DIFF
--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -40,6 +40,7 @@ from twisted.python.filepath import (
 )
 from twisted.internet.defer import (
     DeferredLock,
+    DeferredList,
     returnValue,
 )
 from twisted.web.error import (
@@ -55,6 +56,10 @@ from .magicpath import (
 from .snapshot import (
     create_snapshot_from_capability,
 )
+from .status import (
+    IStatus,
+)
+
 
 def _exclusively(f):
     @wraps(f)
@@ -264,6 +269,7 @@ class MagicFolderUpdater(object):
     _config = attr.ib(validator=instance_of(MagicFolderConfig))
     _remote_cache = attr.ib(validator=instance_of(RemoteSnapshotCacheService))
     tahoe_client = attr.ib() # validator=instance_of(TahoeClient))
+    _status = attr.ib(validator=provides(IStatus))
     _lock = attr.ib(init=False, factory=DeferredLock)
 
     @_exclusively
@@ -293,12 +299,8 @@ class MagicFolderUpdater(object):
                           name=snapshot.name,
                           capability=snapshot.capability,
                           ) as action:
-            local_path = self._config.magic_path.preauthChild(magic2path(snapshot.name))
-            #FIXME: we should not download the file if we aren't going to use it
-            # particularly if we do so synchronously.
-            # For example, we will download the contents of out-of-date snapshots
-            # every scan
-            staged = yield self._magic_fs.download_content_to_staging(snapshot, self.tahoe_client)
+            relpath = magic2path(snapshot.name)
+            local_path = self._config.magic_path.preauthChild(relpath)
 
             # see if we have existing local or remote snapshots for
             # this name already
@@ -359,6 +361,12 @@ class MagicFolderUpdater(object):
                 # XXX we don't handle deletes yet
                 assert not local_snap and not remote_cap, "Internal inconsistency: record of a Snapshot for this name but no local file"
                 is_conflict = False
+
+            self._status.download_started(self._config.name, relpath)
+            try:
+                staged = yield self._magic_fs.download_content_to_staging(snapshot, self.tahoe_client)
+            finally:
+                self._status.download_finished(self._config.name, relpath)
 
             # once here, we know if we have a conflict or not. if
             # there is nothing to do, we shold have returned
@@ -521,18 +529,20 @@ class DownloaderService(service.MultiService):
 
     _config = attr.ib()
     _participants = attr.ib()
+    _status = attr.ib()
     _remote_snapshot_cache = attr.ib(validator=instance_of(RemoteSnapshotCacheService))
     _folder_updater = attr.ib(validator=instance_of(MagicFolderUpdater))
     _tahoe_client = attr.ib()
 
     @classmethod
-    def from_config(cls, name, config, participants, remote_snapshot_cache, folder_updater, tahoe_client):
+    def from_config(cls, name, config, participants, status, remote_snapshot_cache, folder_updater, tahoe_client):
         """
         Create a DownloaderService from the MagicFolder configuration.
         """
         return cls(
             config,
             participants,
+            status,
             remote_snapshot_cache,
             folder_updater,
             tahoe_client,
@@ -562,6 +572,8 @@ class DownloaderService(service.MultiService):
     @inline_callbacks
     def _scan_collective(self):
         action = start_action(action_type="downloader:scan-collective")
+
+        pending_work = []
         with action:
             try:
                 people = yield self._participants.list()
@@ -586,15 +598,36 @@ class DownloaderService(service.MultiService):
                         abspath=fpath.path,
                         relpath=relpath,
                     )
-                    snapshot = yield self._remote_snapshot_cache.get_snapshot_from_capability(snapshot_cap)
-                    # if this remote matches what we believe to be the
-                    # latest, there is nothing to do .. otherwise, we
-                    # have to figure out what to do
-                    try:
-                        our_snapshot_cap = self._config.get_remotesnapshot(snapshot.name)
-                    except KeyError:
-                        our_snapshot_cap = None
-                    if snapshot.capability != our_snapshot_cap:
-                        if our_snapshot_cap is not None:
-                            yield self._remote_snapshot_cache.get_snapshot_from_capability(our_snapshot_cap)
-                        yield self._folder_updater.add_remote_snapshot(snapshot)
+
+                    d = self._process_snapshot(snapshot_cap, relpath)
+                    pending_work.append(d)
+
+                    def error(f):
+                        # probably want to surface somewhere
+                        # (depending on what the error is)
+                        print(f)
+                    d.addErrback(error)
+        yield DeferredList(pending_work)
+
+    @inline_callbacks
+    def _process_snapshot(self, snapshot_cap, relpath):
+        """
+        Internal helper.
+
+        Does the work of caching and acting on a single remote
+        Snapshot.
+
+        :returns Deferred: fires with None upon completion
+        """
+        snapshot = yield self._remote_snapshot_cache.get_snapshot_from_capability(snapshot_cap)
+        # if this remote matches what we believe to be the
+        # latest, there is nothing to do .. otherwise, we
+        # have to figure out what to do
+        try:
+            our_snapshot_cap = self._config.get_remotesnapshot(snapshot.name)
+        except KeyError:
+            our_snapshot_cap = None
+        if snapshot.capability != our_snapshot_cap:
+            if our_snapshot_cap is not None:
+                yield self._remote_snapshot_cache.get_snapshot_from_capability(our_snapshot_cap)
+            yield self._folder_updater.add_remote_snapshot(snapshot)

--- a/src/magic_folder/magic_folder.py
+++ b/src/magic_folder/magic_folder.py
@@ -110,6 +110,7 @@ class MagicFolder(service.MultiService):
                 name=name,
                 config=mf_config,
                 participants=initial_participants,
+                status=status_service,
                 remote_snapshot_cache=remote_snapshot_cache_service,
                 folder_updater=MagicFolderUpdater(
                     LocalMagicFolderFilesystem(
@@ -119,6 +120,7 @@ class MagicFolder(service.MultiService):
                     mf_config,
                     remote_snapshot_cache_service,
                     tahoe_client,
+                    status_service,
                 ),
                 tahoe_client=tahoe_client,
             ),

--- a/src/magic_folder/service.py
+++ b/src/magic_folder/service.py
@@ -140,7 +140,7 @@ class MagicFolderService(MultiService):
         return cls(
             reactor,
             config,
-            WebSocketStatusService(),
+            WebSocketStatusService(reactor, config),
         )
 
     def _when_connected_enough(self):

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -135,7 +135,7 @@ class ListMagicFolder(AsyncTestCase):
             # for these tests, we never contact Tahoe so we can get
             # away with an "empty" Tahoe WebUI
             create_tahoe_client(DecodedURL.from_text(u""), StubTreq(Resource())),
-            WebSocketStatusService(),
+            WebSocketStatusService(reactor, self.config),
         )
 
     @inline_callbacks

--- a/src/magic_folder/test/fixtures.py
+++ b/src/magic_folder/test/fixtures.py
@@ -46,6 +46,7 @@ from twisted.python.filepath import (
 )
 from twisted.internet.task import (
     deferLater,
+    Clock,
 )
 from twisted.internet.defer import (
     Deferred,
@@ -89,6 +90,7 @@ from ..status import (
 from ..config import (
     SQLite3DatabaseLocation,
     MagicFolderConfig,
+    create_testing_configuration,
 )
 
 class INTRODUCER(object):
@@ -404,10 +406,14 @@ class RemoteSnapshotCreatorFixture(Fixture):
             self.poll_interval,
         )
 
+        self._global_config = create_testing_configuration(
+            self.temp.child(b"config"),
+            self.temp.child(b"tahoe-node"),
+        )
         self.remote_snapshot_creator = RemoteSnapshotCreator(
             config=self.config,
             local_author=self.author,
             tahoe_client=self.tahoe_client,
             upload_dircap=self.upload_dircap,
-            status=WebSocketStatusService(),
+            status=WebSocketStatusService(Clock(), self._global_config),
         )

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -416,7 +416,7 @@ class UpdateTests(AsyncTestCase):
             DecodedURL.from_text("http://invalid./"),
             self.http_client,
         )
-        self.status_service = WebSocketStatusService()
+        self.status_service = WebSocketStatusService(reactor, self._global_config)
         self.service = MagicFolder.from_config(
             reactor,
             self.tahoe_client,
@@ -677,7 +677,8 @@ class ConflictTests(AsyncTestCase):
             tahoe_client=create_tahoe_client(
                 DecodedURL.from_text(u"http://invalid./"),
                 StubTreq(StringStubbingResource(get_resource_for)),
-            )
+            ),
+            status=WebSocketStatusService(reactor, self._global_config),
         )
 
     @inline_callbacks

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -908,6 +908,5 @@ class ConflictTests(AsyncTestCase):
         self.assertThat(
             self.filesystem.actions,
             Equals([
-                ("download", parent),
             ])
         )

--- a/src/magic_folder/test/test_local_snapshot.py
+++ b/src/magic_folder/test/test_local_snapshot.py
@@ -20,7 +20,10 @@ from twisted.python.filepath import (
     FilePath,
 )
 
-from twisted.internet import defer
+from twisted.internet import (
+    defer,
+    reactor,
+)
 
 from testtools.matchers import (
     Equals,
@@ -52,6 +55,7 @@ from ..magicpath import (
 )
 from ..config import (
     create_global_configuration,
+    create_testing_configuration,
 )
 from ..status import (
     WebSocketStatusService,
@@ -92,13 +96,19 @@ class LocalSnapshotServiceTests(SyncTestCase):
         Hypothesis-invoked hook to create per-example state.
         Reset the database before running each test.
         """
+        self._node_dir = FilePath(self.mktemp())
+        self._node_dir.makedirs()
+        self._global_config = create_testing_configuration(
+            FilePath(self.mktemp()),
+            self._node_dir,
+        )
         self.magic_path = FilePath(self.mktemp()).asTextMode("utf-8")
         self.magic_path.asBytesMode("utf-8").makedirs()
         self.snapshot_creator = MemorySnapshotCreator()
         self.snapshot_service = LocalSnapshotService(
             magic_path=self.magic_path,
             snapshot_creator=self.snapshot_creator,
-            status=WebSocketStatusService(),
+            status=WebSocketStatusService(reactor, self._global_config),
         )
 
 

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -97,7 +97,7 @@ class MagicFolderServiceTests(SyncTestCase):
             name=name,
             local_snapshot_service=local_snapshot_service,
             uploader_service=Service(),
-            status_service=WebSocketStatusService(),
+            status_service=WebSocketStatusService(reactor, None),
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
             initial_participants=participants,
@@ -125,8 +125,8 @@ class MagicFolderServiceTests(SyncTestCase):
         target_path.asBytesMode("utf-8").setContent(content)
 
         local_snapshot_creator = MemorySnapshotCreator()
-        local_snapshot_service = LocalSnapshotService(magic_path, local_snapshot_creator, WebSocketStatusService())
         clock = object()
+        local_snapshot_service = LocalSnapshotService(magic_path, local_snapshot_creator, WebSocketStatusService(clock, object()))
 
         tahoe_client = object()
         name = u"local-snapshot-service-test"
@@ -138,7 +138,7 @@ class MagicFolderServiceTests(SyncTestCase):
             name=name,
             local_snapshot_service=local_snapshot_service,
             uploader_service=Service(),
-            status_service=WebSocketStatusService(),
+            status_service=WebSocketStatusService(None, None),
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
             initial_participants=participants,
@@ -169,7 +169,7 @@ class MagicFolderServiceTests(SyncTestCase):
         magic_path.asBytesMode("utf-8").makedirs()
 
         local_snapshot_creator = MemorySnapshotCreator()
-        local_snapshot_service = LocalSnapshotService(magic_path, local_snapshot_creator, WebSocketStatusService())
+        local_snapshot_service = LocalSnapshotService(magic_path, local_snapshot_creator, WebSocketStatusService(None, None))
         clock = task.Clock()
 
         # create RemoteSnapshotCreator and UploaderService
@@ -185,7 +185,7 @@ class MagicFolderServiceTests(SyncTestCase):
             name=name,
             local_snapshot_service=local_snapshot_service,
             uploader_service=uploader_service,
-            status_service=WebSocketStatusService(),
+            status_service=WebSocketStatusService(None, None),
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
             initial_participants=participants,
@@ -281,7 +281,7 @@ class MagicFolderFromConfigTests(SyncTestCase):
             tahoe_client,
             name,
             global_config,
-            WebSocketStatusService(),
+            WebSocketStatusService(reactor, global_config),
         )
 
         magic_folder.startService()

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -336,7 +336,7 @@ def treq_for_folders(reactor, basedir, auth_token, folders, start_folder_service
     global_service = MagicFolderService(
         reactor,
         global_config,
-        WebSocketStatusService(),
+        WebSocketStatusService(reactor, global_config),
         # Provide a TahoeClient so MagicFolderService doesn't try to look up a
         # Tahoe-LAFS node URL in the non-existent directory we supplied above
         # in its efforts to create one itself.
@@ -351,7 +351,7 @@ def treq_for_folders(reactor, basedir, auth_token, folders, start_folder_service
         for name in folders:
             global_service.get_folder_service(name).startService()
 
-    return create_testing_http_client(reactor, global_config, global_service, lambda: auth_token, tahoe_client, WebSocketStatusService())
+    return create_testing_http_client(reactor, global_config, global_service, lambda: auth_token, tahoe_client, WebSocketStatusService(reactor, global_config))
 
 
 def magic_folder_config(author, local_directory):

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -51,8 +51,9 @@ from .status import (
 from .config import (
     MagicFolderConfig,
 )
-from . import (
-    magicpath,
+from .magicpath import (
+    magic2path,
+    path2magic,
 )
 
 
@@ -111,7 +112,7 @@ class LocalSnapshotCreator(object):
             # snapshot for the file being added.
             # If so, we use that as the parent.
             relpath = u"/".join(path.segmentsFrom(self._magic_dir))
-            mangled_name = magicpath.path2magic(relpath)
+            mangled_name = path2magic(relpath)
             try:
                 parent_snapshot = self._db.get_local_snapshot(mangled_name)
             except KeyError:
@@ -274,11 +275,8 @@ class RemoteSnapshotCreator(object):
         # get the mangled paths for the LocalSnapshot objects in the db
         localsnapshot_names = self._config.get_all_localsnapshot_paths()
 
-        # update our status if we have nothing to do
-        if len(localsnapshot_names):
-            self._status.upload_started(self._config.name)
-        else:
-            self._status.upload_stopped(self._config.name)
+        for name in localsnapshot_names:
+            self._status.upload_queued(self._config.name, magic2path(name))
 
         # XXX: processing this table should be atomic. i.e. While the upload is
         # in progress, a new snapshot can be created on a file we already uploaded
@@ -289,6 +287,7 @@ class RemoteSnapshotCreator(object):
             action = UPLOADER_SERVICE_UPLOAD_LOCAL_SNAPSHOTS(relpath=name)
             try:
                 with action:
+                    self._status.upload_started(self._config.name, magic2path(name))
                     yield self._upload_some_snapshots(name)
             except Exception:
                 # XXX this existing comment is wrong; there are many
@@ -298,6 +297,9 @@ class RemoteSnapshotCreator(object):
                 # errors or because the tahoe storage nodes are
                 # offline. Retry?
                 print(Failure())
+            finally:
+                self._status.upload_finished(self._config.name, magic2path(name))
+
 
     @inline_callbacks
     def _upload_some_snapshots(self, name):


### PR DESCRIPTION
Per-folder status information.

It's clear we need some sort of per-folder information. It's not clear precisely _what_ but this puts in some infrastructure for that and a couple ideas (derived from the use-cases in the existing -- incomplete -- lightweight-design).

Currently this will tell listeners about ephemeral uploader and downloader information. (Clients _should not_ be trying to remember that themselves -- but this doesn't yet tackle a "last 30 updates" type thing as also implied by the existing use-cases).
 