### PR TITLE
Capture eliot logging in integration tests.

### DIFF
--- a/src/magic_folder/api_cli.py
+++ b/src/magic_folder/api_cli.py
@@ -43,6 +43,7 @@ from .client import (
     create_http_client,
     create_magic_folder_client,
 )
+from .util.eliotutil import maybe_enable_eliot_logging, with_eliot_options
 
 
 class AddSnapshotOptions(usage.Options):
@@ -220,6 +221,7 @@ def monitor(options):
     return Deferred()
 
 
+@with_eliot_options
 class MagicFolderApiCommand(usage.Options):
     """
     top-level command (entry-point is "magic-folder-api")
@@ -379,6 +381,8 @@ def run_magic_folder_api_options(options):
         "list-participants": list_participants,
         "monitor": monitor,
     }[options.subCommand]
+
+    maybe_enable_eliot_logging(options)
 
     # we want to let exceptions out to the top level if --debug is on
     # because this gives better stack-traces

--- a/src/magic_folder/test/test_eliotutil.py
+++ b/src/magic_folder/test/test_eliotutil.py
@@ -127,7 +127,7 @@ class EliotLoggingTests(TestCase):
         destination.
         """
         collected = []
-        service = _EliotLogging([collected.append])
+        service = _EliotLogging([collected.append], capture_logs=True)
         service.startService()
         self.addCleanup(service.stopService)
 
@@ -151,7 +151,7 @@ class EliotLoggingTests(TestCase):
         destination.
         """
         collected = []
-        service = _EliotLogging([collected.append])
+        service = _EliotLogging([collected.append], capture_logs=True)
         service.startService()
         self.addCleanup(service.stopService)
 


### PR DESCRIPTION
Fixes #448. See #367.

Right now, the `magic-folder` CLI command always generate eliot logs in a `magic-folder-cli.{pid}.eliot` file in the current directory. This isn't great for a couple of reason:
- it is inconsiderate to pollute the user's working directory with a bunch of log files
- it makes hard to capture the logs of service in a way that is easy to access later

This PR implements enough control over eliot logging to be able capture the logs in the integration tests logs[1], and adds support for capturing them.
- Remove the existing automatically generated log files.
  - For non-service CLI commands, we don't currently generate any logs, so we are creating a bunch of empty files.
  - For service invocations, the new options provide a better means of capturing the logs.
- Add an `--eliot-fd` option to pass a file-descriptor to write logs to. The integration tests have the service write to FD 3 to capture logs.
- Add an `--eliot-task-fields` option which causes magic-folder to create a new top-level action (with fields provided by a JSON dict provided by this option) that is the ancestor of all logs from the service. This is used by the integration tests to make navigating the logs from each node and each run of the service easier (the node is a field of the root action, and each run has its own root action containing all the logs from the run).
- The integration tests are updated to pass the new options when running the service, and to collect the output from FD 3 of the service, and feed the logs back into its own eliot logger.


[1] Currently, to inspect the logs, what I've been doing to read them is:
1. Before running the tests, delete all the existing `magic-folder-cli.*.eliot` files (or often, after running the tests and realizing I need access to the logs, deleting them and running the tests again.
2. Run the tests.
3. Look through the logs by passing a glob to eliot-tree or, if I need to differentiate between different instances of the service, using `wc -l *.eliot` to identify which logs are from services (as opposed to other CLI commands, which don't currently generate any eliot logs), and then try to find the service instance I'm interested in.