### PR TITLE
Improve eliot logging in integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,8 +276,6 @@ jobs:
       <<: *UTF_8_ENVIRONMENT
       # Select the integration tests tox environments.
       MAGIC_FOLDER_TOX_ENVIRONMENT: "integration-junit"
-      # Disable artifact collection because py.test can't produce any.
-      ARTIFACTS_OUTPUT_PATH: ""
 
     steps:
       - "checkout"
@@ -294,8 +292,6 @@ jobs:
       <<: *UTF_8_ENVIRONMENT
       # Select the integration tests tox environments.
       MAGIC_FOLDER_TOX_ENVIRONMENT: "integration-1_14-junit"
-      # Disable artifact collection because py.test can't produce any.
-      ARTIFACTS_OUTPUT_PATH: ""
 
   integration-master:
     <<: *INTEGRATION
@@ -304,8 +300,6 @@ jobs:
       <<: *UTF_8_ENVIRONMENT
       # Select the integration tests tox environments.
       MAGIC_FOLDER_TOX_ENVIRONMENT: "integration-master-junit"
-      # Disable artifact collection because py.test can't produce any.
-      ARTIFACTS_OUTPUT_PATH: ""
 
 
   ubuntu-18.04:

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -81,10 +81,14 @@ ${TIMEOUT} "${BOOTSTRAP_VENV}"/bin/tox \
     ${MAGIC_FOLDER_TOX_ARGS} || "${alternative}"
 
 if [ -n "${ARTIFACTS}" ]; then
-    "${BOOTSTRAP_VENV}"/bin/eliot-prettyprint < "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot.txt
-    "${BOOTSTRAP_VENV}"/bin/eliot-tree --field-limit=0 "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot-tree.txt
+    if [ -f "${PROJECT_ROOT}/eliot.log" ]; then
+        "${BOOTSTRAP_VENV}"/bin/eliot-prettyprint < "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot.txt
+        "${BOOTSTRAP_VENV}"/bin/eliot-tree --field-limit=0 "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot-tree.txt
+    fi
 
-    # Create a junitxml results area.
-    mkdir -p "$(dirname "${JUNITXML}")"
-    "${BOOTSTRAP_VENV}"/bin/subunit2junitxml < "${SUBUNIT2}" > "${JUNITXML}" || "${alternative}"
+    if [ -f "${SUBUNIT2}" ]; then
+        # Create a junitxml results area.
+        mkdir -p "$(dirname "${JUNITXML}")"
+        "${BOOTSTRAP_VENV}"/bin/subunit2junitxml < "${SUBUNIT2}" > "${JUNITXML}" || "${alternative}"
+    fi
 fi

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -29,12 +29,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel tox
+        pip install wheel tox eliot-tree
     - name: Test with tox
       env:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
       run: |
         tox -e py27-coverage
+
+    - name: Generate eliot-tree.
+      if: ${{ always() }}
+      run: |
+        eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
 
     - name: Upload eliot.log in case of failure
       uses: "actions/upload-artifact@v2"
@@ -42,7 +47,7 @@ jobs:
       with:
         if-no-files-found: "warn"
         name: "unit-test"
-        path: "eliot.log"
+        path: "eliot*"
 
     - uses: codecov/codecov-action@v1
       with:
@@ -69,10 +74,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel tox
+        pip install wheel tox eliot-tree
     - name: Test with tox
       run: |
         tox -e integration
+
+    - name: Generate eliot-tree.
+      if: ${{ always() }}
+      run: |
+        eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
 
     - name: Upload eliot.log in case of failure
       uses: "actions/upload-artifact@v2"
@@ -80,7 +90,7 @@ jobs:
       with:
         if-no-files-found: "warn"
         name: "integration"
-        path: "eliot.log"
+        path: "eliot*"
 
     - uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -36,6 +36,14 @@ jobs:
       run: |
         tox -e py27-coverage
 
+    - name: Upload eliot.log in case of failure
+      uses: "actions/upload-artifact@v2"
+      if: ${{ always() }}
+      with:
+        if-no-files-found: "warn"
+        name: "unit-test"
+        path: "eliot.log"
+
     - uses: codecov/codecov-action@v1
       with:
         token: "322d708d-8283-4827-b605-ccf02bfecf70"
@@ -65,6 +73,14 @@ jobs:
     - name: Test with tox
       run: |
         tox -e integration
+
+    - name: Upload eliot.log in case of failure
+      uses: "actions/upload-artifact@v2"
+      if: ${{ always() }}
+      with:
+        if-no-files-found: "warn"
+        name: "integration"
+        path: "eliot.log"
 
     - uses: codecov/codecov-action@v1
       with:

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -66,7 +66,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True, scope='session')
 def eliot_logging():
-    with open("integration.eliot.json", "w") as f:
+    with open("eliot.log", "w") as f:
         to_file(f)
         yield
 

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -11,7 +11,7 @@ from pathlib2 import Path
 from time import sleep
 from os import mkdir, listdir, environ
 from os.path import join, exists
-from tempfile import mkdtemp, mktemp
+from tempfile import mkdtemp
 from functools import partial
 
 from configparser import ConfigParser
@@ -202,7 +202,7 @@ def flog_gatherer(reactor, temp_dir, flog_binary, request):
         def cleanup():
             _cleanup_tahoe_process(twistd_process, twistd_protocol.exited)
 
-            flog_file = mktemp('.flog_dump')
+            flog_file = 'integration.flog_dump'
             flog_protocol = _DumpOutputProtocol(open(flog_file, 'w'))
             flog_dir = join(temp_dir, 'flog_gather')
             flogs = [x for x in listdir(flog_dir) if x.endswith('.flog')]

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -23,6 +23,7 @@ from foolscap.furl import (
 from eliot import (
     to_file,
     log_call,
+    start_task,
 )
 
 from twisted.python.procutils import which
@@ -68,6 +69,12 @@ def pytest_addoption(parser):
 def eliot_logging():
     with open("eliot.log", "w") as f:
         to_file(f)
+        yield
+
+
+@pytest.fixture(autouse=True, scope='function')
+def eliot_log_test(request):
+    with start_task(action_type="integration:pytest", test=str(request.node.nodeid)):
         yield
 
 

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -290,7 +290,6 @@ tub.location = tcp:localhost:9321
 
 
 @pytest.fixture(scope='session')
-@log_call(action_type=u"integration:introducer:furl", include_args=["temp_dir"])
 def introducer_furl(introducer, temp_dir):
     furl_fname = join(temp_dir, 'introducer', 'private', 'introducer.furl')
     while not exists(furl_fname):
@@ -305,7 +304,6 @@ def introducer_furl(introducer, temp_dir):
 
 
 @pytest.fixture(scope='session')
-@log_call(action_type=u"integration:alice", include_args=[], include_result=False)
 def alice(reactor, tahoe_venv, temp_dir, introducer_furl, flog_gatherer, request):
     try:
         mkdir(join(temp_dir, 'magic-alice'))
@@ -330,7 +328,6 @@ def alice(reactor, tahoe_venv, temp_dir, introducer_furl, flog_gatherer, request
 
 
 @pytest.fixture(scope='session')
-@log_call(action_type=u"integration:bob", include_args=[], include_result=False)
 def bob(reactor, tahoe_venv, temp_dir, introducer_furl, flog_gatherer, request):
     try:
         mkdir(join(temp_dir, 'magic-bob'))
@@ -353,7 +350,6 @@ def bob(reactor, tahoe_venv, temp_dir, introducer_furl, flog_gatherer, request):
     )
 
 @pytest.fixture(scope='session')
-@log_call(action_type=u"integration:edmond", include_args=[], include_result=False)
 def edmond(reactor, tahoe_venv, temp_dir, introducer_furl, flog_gatherer, request):
     return pytest_twisted.blockon(
         MagicFolderEnabledNode.create(

--- a/integration/test_add.py
+++ b/integration/test_add.py
@@ -4,15 +4,7 @@ from __future__ import (
     print_function,
 )
 
-from json import (
-    loads,
-)
-
 import pytest_twisted
-
-from . import util
-
-# see "conftest.py" for the fixtures (e.g. "magic_folder")
 
 
 @pytest_twisted.inlineCallbacks
@@ -21,29 +13,13 @@ def test_add(request, reactor, temp_dir, alice):
     'magic-folder add' happy-path works
     """
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
-        [
-            "--config", alice.magic_config_directory,
-            "add",
-            "--name", "test",
-            "--author", "laptop",
-            alice.magic_directory,
-        ],
+    yield alice.add(
+        "test",
+        alice.magic_directory,
+        author="laptop",
     )
-    yield proto.done
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
-        [
-            "--config", alice.magic_config_directory,
-            "show-config",
-        ],
-    )
-    output = yield proto.done
-    config = loads(output)
+    config = yield alice.show_config()
 
     assert "test" in config["magic_folders"]
     mf_config = config["magic_folders"]["test"]

--- a/integration/test_general_cli.py
+++ b/integration/test_general_cli.py
@@ -32,9 +32,8 @@ def test_daemon_inititialize(request, reactor, temp_dir):
     with open(join(tahoe_dir, "node.url"), "w") as f:
         f.write('http://localhost:1234/')
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
+    yield util._magic_folder_runner(
+        reactor, request, "daemon",
         [
             "--config", node_dir,
             "init",
@@ -42,17 +41,14 @@ def test_daemon_inititialize(request, reactor, temp_dir):
             "--node-directory", tahoe_dir,
         ],
     )
-    yield proto.done
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
+    output = yield util._magic_folder_runner(
+        reactor, request, "daemon",
         [
             "--config", node_dir,
             "show-config",
         ],
     )
-    output = yield proto.done
     config = loads(output)
 
     assert config["api_endpoint"] == "tcp:1234"
@@ -76,9 +72,8 @@ def test_daemon_migrate(request, reactor, alice, temp_dir):
     with open(join(alice.node_directory, "private", "magic_folders.yaml"), "w") as f:
         f.write("magic-folders: {}\n")
 
-    proto = util._DumpOutputProtocol(None)
-    util._magic_folder_runner(
-        proto, reactor, request,
+    yield util._magic_folder_runner(
+        reactor, request, "migrate",
         [
             "--config", node_dir,
             "migrate",
@@ -87,17 +82,14 @@ def test_daemon_migrate(request, reactor, alice, temp_dir):
             "--author", "test",
         ],
     )
-    yield proto.done
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
+    output = yield util._magic_folder_runner(
+        reactor, request, "migrate",
         [
             "--config", node_dir,
             "show-config",
         ],
     )
-    output = yield proto.done
     config = loads(output)
 
     assert config["api_endpoint"] == "tcp:1234"

--- a/integration/test_list.py
+++ b/integration/test_list.py
@@ -47,23 +47,20 @@ def test_list(request, reactor, tahoe_venv, temp_dir, introducer_furl, flog_gath
             storage=True,
         )
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
+    output = yield util._magic_folder_runner(
+        reactor, request, "zelda",
         [
             "--config", zelda.magic_config_directory,
             "list",
         ],
     )
-    output = yield proto.done
     assert output.strip() == "No magic-folders"
 
     magic_dir = FilePath(temp_dir).child("zelda-magic")
     magic_dir.makedirs()
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
+    output = yield util._magic_folder_runner(
+        reactor, request, "zelda",
         [
             "--config", zelda.magic_config_directory,
             "add",
@@ -72,18 +69,15 @@ def test_list(request, reactor, tahoe_venv, temp_dir, introducer_furl, flog_gath
             magic_dir.path,
         ],
     )
-    output = yield proto.done
 
-    proto = util._CollectOutputProtocol()
-    util._magic_folder_runner(
-        proto, reactor, request,
+    output = yield util._magic_folder_runner(
+        reactor, request, "zelda",
         [
             "--config", zelda.magic_config_directory,
             "list",
             "--json",
         ],
     )
-    output = yield proto.done
     data = json.loads(output)
 
     assert list(data.keys()) == ["workstuff"]

--- a/integration/util.py
+++ b/integration/util.py
@@ -409,9 +409,9 @@ class _MagicTextProtocol(ProcessProtocol):
             Message.log(message_type=u"out-received", data=data)
             sys.stdout.write(data)
             self._output.write(data)
-            if not self.magic_seen.called and self._magic_text in self._output.getvalue():
-                print("Saw '{}' in the logs".format(self._magic_text))
-                self.magic_seen.callback(self)
+        if not self.magic_seen.called and self._magic_text in self._output.getvalue():
+            print("Saw '{}' in the logs".format(self._magic_text))
+            self.magic_seen.callback(self)
 
     def errReceived(self, data):
         with self._action.context():

--- a/integration/util.py
+++ b/integration/util.py
@@ -17,7 +17,6 @@ from functools import partial
 import attr
 
 from twisted.internet.defer import (
-    inlineCallbacks,
     returnValue,
     Deferred,
     succeed,
@@ -45,6 +44,7 @@ from eliot import (
 )
 from eliot.twisted import (
     DeferredContext,
+    inline_callbacks,
 )
 
 from allmydata.util.configutil import (
@@ -101,7 +101,7 @@ class MagicFolderEnabledNode(object):
         return join(self.temp_dir, "magic-{}".format(self.name))
 
     @classmethod
-    @inlineCallbacks
+    @inline_callbacks
     def create(
             cls,
             reactor,
@@ -183,7 +183,7 @@ class MagicFolderEnabledNode(object):
             )
         )
 
-    @inlineCallbacks
+    @inline_callbacks
     def stop_magic_folder(self):
         if self.magic_folder is None:
             return
@@ -194,12 +194,12 @@ class MagicFolderEnabledNode(object):
         except ProcessExitedAlready:
             pass
 
-    @inlineCallbacks
+    @inline_callbacks
     def restart_magic_folder(self):
         yield self.stop_magic_folder()
         yield self.start_magic_folder()
 
-    @inlineCallbacks
+    @inline_callbacks
     def start_magic_folder(self):
         with start_action(action_type=u"integration:alice:magic_folder:magic-text"):
             self.magic_folder = yield _run_magic_folder(
@@ -217,7 +217,7 @@ class MagicFolderEnabledNode(object):
 
     # magic-folder CLI API helpers
 
-    @inlineCallbacks
+    @inline_callbacks
     def add(self, folder_name, magic_directory, author=None, poll_interval=5):
         """
         magic-folder add
@@ -237,7 +237,7 @@ class MagicFolderEnabledNode(object):
         yield proto.done
         returnValue(proto.output.getvalue())
 
-    @inlineCallbacks
+    @inline_callbacks
     def leave(self, folder_name):
         """
         magic-folder add
@@ -255,7 +255,7 @@ class MagicFolderEnabledNode(object):
         yield proto.done
         returnValue(proto.output.getvalue())
 
-    @inlineCallbacks
+    @inline_callbacks
     def show_config(self):
         """
         magic-folder show-config
@@ -272,7 +272,7 @@ class MagicFolderEnabledNode(object):
         config = json.loads(output)
         returnValue(config)
 
-    @inlineCallbacks
+    @inline_callbacks
     def list_(self, include_secret_information=None):
         """
         magic-folder list
@@ -294,7 +294,7 @@ class MagicFolderEnabledNode(object):
         config = json.loads(output)
         returnValue(config)
 
-    @inlineCallbacks
+    @inline_callbacks
     def add_snapshot(self, folder_name, relpath):
         """
         magic-folder-api add-snapshot
@@ -312,7 +312,7 @@ class MagicFolderEnabledNode(object):
         yield proto.done
         returnValue(proto.output.getvalue())
 
-    @inlineCallbacks
+    @inline_callbacks
     def add_participant(self, folder_name, author_name, personal_dmd):
         """
         magic-folder-api add-participant
@@ -331,7 +331,7 @@ class MagicFolderEnabledNode(object):
         yield proto.done
         returnValue(proto.output.getvalue())
 
-    @inlineCallbacks
+    @inline_callbacks
     def dump_state(self, folder_name):
         """
         magic-folder-api dump-state
@@ -772,7 +772,7 @@ def _check_status(response):
         )
 
 
-@inlineCallbacks
+@inline_callbacks
 def web_get(tahoe, uri_fragment, **kwargs):
     """
     Make a GET request to the webport of `tahoe` (a `TahoeProcess`,
@@ -791,7 +791,7 @@ def twisted_sleep(reactor, timeout):
     return deferLater(reactor, timeout, lambda: None)
 
 
-@inlineCallbacks
+@inline_callbacks
 def await_client_ready(reactor, tahoe, timeout=10, liveness=60*2):
     """
     Uses the status API to wait for a client-type node (in `tahoe`, a
@@ -955,7 +955,7 @@ def _run_magic_folder(reactor, request, temp_dir, name):
         return ctx.addActionFinish()
 
 
-@inlineCallbacks
+@inline_callbacks
 def _pair_magic_folder(reactor, alice_invite, alice, bob):
     print("Joining bob to magic-folder")
     yield _command(
@@ -974,7 +974,7 @@ def _pair_magic_folder(reactor, alice_invite, alice, bob):
     returnValue((alice.magic_directory, bob.magic_directory))
 
 
-@inlineCallbacks
+@inline_callbacks
 def _generate_invite(reactor, inviter, invitee_name):
     """
     Create a new magic-folder invite.
@@ -1009,7 +1009,7 @@ def _generate_invite(reactor, inviter, invitee_name):
 
 
 
-@inlineCallbacks
+@inline_callbacks
 def _command(*args):
     """
     Runs a single magic-folder command with the given arguments as CLI

--- a/newsfragments/449.minor
+++ b/newsfragments/449.minor
@@ -1,0 +1,1 @@
+Add your info here

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings = 
+    # This is a poor interaction of eliot's inline_callbacks and twisted
+    # Once we are on python 3, we can stop using returnValue at all.
+    ignore:.*returnValue should only be invoked by functions decorated with inlineCallbacks.*


### PR DESCRIPTION
Cleanup all the existing eliot logging in the integration tests, in preparation for capturing the logs from the services. (see #445)

The main goal here is to ensure that all eliot logs are captured in an appropriate action (in particular one that hasn't been finished, as eliot won't associate messages from after action was finished, when parsing).

This add a bunch of wrappers to the code for running services and commands, to ensure that logs for each process are consistently captured in a given action, and  that that action doesn't end until the process does.

This also puts foolscap log capturing behind a pytest option, as I think that is unlikely to be useful to magic-folder developers most of the time.