### PR TITLE
Add an endpoint to request a scan of a magic folder.

### DIFF
--- a/integration/test_synchronize.py
+++ b/integration/test_synchronize.py
@@ -35,9 +35,19 @@ def add_snapshot(node, folder_name, path):
     """
     Take a snapshot of the given path in the given magic folder.
 
-    :param MagigFolderEnabledNode node: The node on which to take the snapshot.
+    :param MagicFolderEnabledNode node: The node on which to take the snapshot.
     """
     return node.add_snapshot(folder_name, path)
+
+
+def scan_folder(node, folder_name, path):
+    """
+    Scan the given magic folder. This should cause the given path to be
+    snapshotted.
+
+    :param MagicFolderEnabledNode node: The node on which to do the scan.
+    """
+    return node.scan_folder(folder_name)
 
 
 def periodic_scan(node, folder_name, path):
@@ -46,7 +56,7 @@ def periodic_scan(node, folder_name, path):
     This should cause the given path to be
     snapshotted.
 
-    :param MagigFolderEnabledNode node: The node on which to do the scan.
+    :param MagicFolderEnabledNode node: The node on which to do the scan.
     """
     Message.log(message_type="integration:wait_for_scan", node=node.name, folder=folder_name)
     time.sleep(1)
@@ -66,6 +76,7 @@ def enable_periodic_scans(magic_folder_nodes, monkeypatch):
 @pytest.fixture(
     params=[
         add_snapshot,
+        scan_folder,
         pytest.lazy_fixture('periodic_scan'),
     ]
 )

--- a/integration/util.py
+++ b/integration/util.py
@@ -330,6 +330,19 @@ class MagicFolderEnabledNode(object):
             ],
         )
 
+    def scan_folder(self, folder_name):
+        """
+        magic-folder-api scan-folder
+        """
+        return _magic_folder_api_runner(
+            self.reactor, self.request, self.name,
+            [
+                "--config", self.magic_config_directory,
+                "scan-folder",
+                "--folder", folder_name,
+            ],
+        )
+
     def add_participant(self, folder_name, author_name, personal_dmd):
         """
         magic-folder-api add-participant

--- a/src/magic_folder/api_cli.py
+++ b/src/magic_folder/api_cli.py
@@ -174,6 +174,25 @@ def list_participants(options):
     print("{}".format(json.dumps(res, indent=4)), file=options.stdout)
 
 
+class ScanFolderOptions(usage.Options):
+    optParameters = [
+        ("folder", "n", None, "Name of the magic-folder participants to scan", to_unicode),
+    ]
+
+    def postOptions(self):
+        required_args = [
+            ("folder", "--folder / -n is required"),
+        ]
+        for (arg, error) in required_args:
+            if self[arg] is None:
+                raise usage.UsageError(error)
+
+def scan_folder(options):
+    return options.parent.client.scan_folder(
+        options['folder'],
+    )
+
+
 class MonitorOptions(usage.Options):
     optFlags = [
         ["once", "", "Exit after receiving a single status message"],
@@ -240,6 +259,7 @@ class MagicFolderApiCommand(BaseOptions):
         ["dump-state", None, DumpStateOptions, "Dump the local state of a magic-folder."],
         ["add-participant", None, AddParticipantOptions, "Add a Participant to a magic-folder."],
         ["list-participants", None, ListParticipantsOptions, "List all Participants in a magic-folder."],
+        ["scan-folder", None, ScanFolderOptions, "Scan for local changes in a magic-folder."],
         ["monitor", None, MonitorOptions, "Monitor status updates."],
     ]
     optFlags = [
@@ -352,6 +372,7 @@ def run_magic_folder_api_options(options):
         "dump-state": dump_state,
         "add-participant": add_participant,
         "list-participants": list_participants,
+        "scan-folder": scan_folder,
         "monitor": monitor,
     }[options.subCommand]
 

--- a/src/magic_folder/cli.py
+++ b/src/magic_folder/cli.py
@@ -518,6 +518,10 @@ def run(options):
 
 @with_eliot_options
 class BaseOptions(usage.Options):
+    stdin = sys.stdin
+    stdout = sys.stdout
+    stderr = sys.stderr
+
     optFlags = [
         ["version", "V", "Display version numbers."],
     ]
@@ -554,11 +558,13 @@ class BaseOptions(usage.Options):
 
     @property
     def client(self):
-        if self._http_client is None:
-            from twisted.internet import reactor
-            self._http_client = create_http_client(reactor, self.config.api_client_endpoint)
         if self._client is None:
             from twisted.internet import reactor
+
+            if self._http_client is None:
+                self._http_client = create_http_client(
+                    reactor, self.config.api_client_endpoint
+                )
             self._client = create_magic_folder_client(
                 reactor,
                 self.config,
@@ -568,9 +574,6 @@ class BaseOptions(usage.Options):
 
 
 class MagicFolderCommand(BaseOptions):
-    stdin = sys.stdin
-    stdout = sys.stdout
-    stderr = sys.stderr
 
     subCommands = [
         ["init", None, InitializeOptions, "Initialize a Magic Folder daemon."],

--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -168,6 +168,12 @@ class MagicFolderClient(object):
             'scan_interval': scan_interval,
         }, ensure_ascii=False).encode('utf-8'))
 
+    def scan_folder(self, magic_folder):
+        api_url = self.base_url.child(u'v1', u'magic-folder', magic_folder, u'scan')
+        return self._authorized_request("PUT", api_url, body=json.dumps({
+            "wait-for-snapshots": True,
+        }))
+
     def leave_folder(self, magic_folder, really_delete_write_capability):
         # type: (unicode, bool) -> dict
         api_url = self.base_url.child(u"v1").child(u"magic-folder").child(magic_folder)

--- a/src/magic_folder/magic_folder.py
+++ b/src/magic_folder/magic_folder.py
@@ -175,6 +175,15 @@ class MagicFolder(service.MultiService):
         """
         return defer.succeed(None)
 
+    def scan(self):
+        """
+        Scan the magic folder for changes.
+
+        :returns Deferred[None]: that fires when all the changed files have
+            been snapshotted.
+        """
+        return self.scanner_service.scan_once()
+
 
 _NICKNAME = Field.for_types(
     u"nickname",

--- a/src/magic_folder/scanner.py
+++ b/src/magic_folder/scanner.py
@@ -140,6 +140,9 @@ def find_updated_files(cooperator, folder_config, on_new_file):
             except KeyError:
                 snapshot_state = None
             path_state = get_pathinfo(path).state
+            # NOTE: Make sure that we get both these states without yielding
+            # to the reactor. Otherwise, we may detect a changed made by us
+            # as a new change.
             if path_state != snapshot_state:
                 # TODO: We may also want to compare checksums here,
                 # to avoid `touch(1)` creating a new snapshot.

--- a/src/magic_folder/test/cli/test_api_cli.py
+++ b/src/magic_folder/test/cli/test_api_cli.py
@@ -1,0 +1,113 @@
+# Copyright 2020 The Magic-Folder Developers
+# See COPYING for details.
+
+"""
+Tests for `magic-folder-api`.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from eliot.twisted import inline_callbacks
+from testtools.matchers import Equals
+from twisted.internet import reactor
+from twisted.python.filepath import FilePath
+
+from ..common import AsyncTestCase
+from ..fixtures import MagicFolderNode
+from .common import api_cli, cli
+
+
+class ScanMagicFolder(AsyncTestCase):
+    def api_cli(self, argv):
+        return api_cli(argv, self.node.global_config, self.node.http_client)
+
+    def cli(self, argv):
+        return cli(argv, self.node.global_config, self.node.http_client)
+
+    @inline_callbacks
+    def setUp(self):
+        """
+        Create a Tahoe-LAFS node which can contain some magic folder configuration
+        and run it.
+        """
+        yield super(ScanMagicFolder, self).setUp()
+
+        self.magic_path = FilePath(self.mktemp())
+        self.magic_path.makedirs()
+        self.folder_name = "default"
+        folders = {
+            self.folder_name: {
+                "magic-path": self.magic_path,
+                "author-name": "author",
+                "poll-interval": 60,
+                "scan-interval": None,
+                "admin": True,
+            }
+        }
+
+        self.config_dir = FilePath(self.mktemp())
+        self.node = MagicFolderNode.create(
+            reactor,
+            self.config_dir,
+            folders=folders,
+            start_folder_services=False,
+        )
+
+        self.folder_config = self.node.global_config.get_magic_folder(self.folder_name)
+        self.folder_service = self.node.global_service.get_folder_service(
+            self.folder_name
+        )
+
+        self.folder_service.local_snapshot_service.startService()
+        self.addCleanup(self.folder_service.local_snapshot_service.stopService)
+
+    @inline_callbacks
+    def test_scan_magic_folder(self):
+        """
+        Scanning a magic folder creates a snapshot of new files.
+        """
+        name = "file"
+        local = self.magic_path.child(name)
+        local.setContent(b"content")
+
+        outcome = yield self.api_cli(
+            [
+                b"scan-folder",
+                b"--folder",
+                self.folder_name.encode("utf-8"),
+            ],
+        )
+        self.assertThat(
+            outcome.succeeded(),
+            Equals(True),
+        )
+
+        snapshot_paths = self.folder_config.get_all_localsnapshot_paths()
+        self.assertThat(
+            snapshot_paths,
+            Equals({name}),
+        )
+
+    @inline_callbacks
+    def test_scan_magic_folder_missing_name(self):
+        """
+        If a folder is not passed to ``magic-folder-api scan-folder``,
+        an error is returned.
+        """
+        name = "file"
+        local = self.magic_path.child(name)
+        local.setContent(b"content")
+
+        outcome = yield self.api_cli(
+            [
+                b"scan-folder",
+            ],
+        )
+        self.assertThat(
+            outcome.succeeded(),
+            Equals(False),
+        )
+        self.assertIn(
+            "--folder / -n is required",
+            outcome.stderr,
+        )

--- a/src/magic_folder/test/test_api_cli.py
+++ b/src/magic_folder/test/test_api_cli.py
@@ -230,7 +230,7 @@ class TestMagicApi(AsyncTestCase):
             IsInstance(GlobalConfigDatabase),
         )
         self.assertThat(
-            options.get_client(),
+            options.client,
             IsInstance(MagicFolderClient),
         )
         self.assertThat(

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -121,6 +121,7 @@ from ..client import (
     authorized_request,
     url_to_bytes,
 )
+from ..magicpath import path2magic
 from .strategies import (
     tahoe_lafs_readonly_dir_capabilities,
     tahoe_lafs_dir_capabilities,

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -361,6 +361,20 @@ class APIv1(object):
         _application_json(request)
         return json.dumps(dict(_list_all_snapshots(self._global_config)))
 
+    @app.route("/magic-folder/<string:folder_name>/scan", methods=['PUT'])
+    @inline_callbacks
+    def scan_folder(self, request, folder_name):
+        folder_service = self._global_service.get_folder_service(folder_name)
+
+        body = _load_json(request.content.read())
+        if body != {"wait-for-snapshots": True}:
+            raise _InputError("Unknown options to scan.")
+
+        yield folder_service.scan()
+
+        _application_json(request)
+        returnValue(b"{}")
+
     @app.route("/magic-folder/<string:folder_name>/snapshot", methods=['POST'])
     @inlineCallbacks
     def add_snapshot(self, request, folder_name):


### PR DESCRIPTION
See #138. 

This is a followup to #465 that adds an API endpoint and corresponding CLI command to request a scan of a folder. It also parameterizes the existing synchronization integration tests, to run them with `add-snapshot` and `scan-folder`.

This also incidentally fixes #333 as part of refactoring some code for the tests.

All the commits are self-contained, and so could be reviewed individually.