### PR TITLE
Initial scanner service

### DIFF
--- a/newsfragments/138.feature
+++ b/newsfragments/138.feature
@@ -1,0 +1,1 @@
+Automated scanning for local changes

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -11,7 +11,6 @@ from __future__ import (
 
 import os
 from collections import deque
-from functools import wraps
 
 import attr
 from attr.validators import (
@@ -58,13 +57,7 @@ from .snapshot import (
     create_snapshot_from_capability,
 )
 from .util.file import PathState, get_pathinfo, seconds_to_ns
-
-def _exclusively(f):
-    @wraps(f)
-    def wrapper(self, *args, **kwargs):
-        return self._lock.run(f, self, *args, **kwargs)
-
-    return wrapper
+from .util.twisted import exclusively
 
 
 @attr.s
@@ -105,7 +98,7 @@ class RemoteSnapshotCacheService(service.Service):
         """
         return cls(config, tahoe_client)
 
-    @_exclusively
+    @exclusively
     @inline_callbacks
     def get_snapshot_from_capability(self, snapshot_cap):
         """
@@ -271,7 +264,7 @@ class MagicFolderUpdater(object):
     tahoe_client = attr.ib() # validator=instance_of(TahoeClient))
     _lock = attr.ib(init=False, factory=DeferredLock)
 
-    @_exclusively
+    @exclusively
     @inline_callbacks
     def add_remote_snapshot(self, snapshot):
         """

--- a/src/magic_folder/scanner.py
+++ b/src/magic_folder/scanner.py
@@ -1,0 +1,131 @@
+# Copyright (c) Least Authority TFA GmbH.
+
+"""
+Scan a Magic Folder for changes.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import attr
+from eliot import start_action, write_failure
+from eliot.twisted import inline_callbacks
+from twisted.application.service import Service
+from twisted.internet.defer import DeferredLock, gatherResults
+from twisted.internet.task import Cooperator
+
+from .magicpath import path2magic
+from .util.file import get_pathinfo
+from .util.twisted import exclusively
+
+
+def _create_cooperator(clock):
+    """
+    Create a cooperator
+    """
+
+    def schedule(f):
+        return clock.callLater(0, f)
+
+    # NOTE: We don't use CooperatorSevice here, since:
+    # - There is not a way to set the reactor it uses
+    # - Once we enable periodic scans, we want to wait to stop the cooperator
+    #   stop it until after the TimerService for periodic scans has stoppped,
+    #   so that the Cooperator will have no pending work.
+    return Cooperator(
+        scheduler=schedule,
+    )
+
+
+@attr.s
+class ScannerService(Service):
+    """
+    Periodically scan a local Magic Folder for new or updated files, and request
+    the local snapshot service snapshot them.
+    """
+
+    _config = attr.ib()
+    _local_snapshot_service = attr.ib()
+    _status = attr.ib()
+    _cooperator = attr.ib()
+    _lock = attr.ib(init=False, factory=DeferredLock)
+
+    @classmethod
+    def from_config(cls, clock, folder_config, local_snapshot_service, status):
+        return cls(
+            config=folder_config,
+            local_snapshot_service=local_snapshot_service,
+            status=status,
+            cooperator=_create_cooperator(clock),
+        )
+
+    def __attrs_post_init__(self):
+        super(ScannerService, self).__init__()
+
+    def stopService(self):
+        super(ScannerService, self).stopService()
+        self._cooperator.stop()
+
+    def scan_once(self):
+        """
+        Perform a scan for new files.
+        """
+        return self._scan()
+
+    @exclusively
+    @inline_callbacks
+    def _scan(self):
+        """
+        Perform a scan for new files, and wait for all the snapshots to be
+        complete.
+        """
+        # TODO: Do we always want to wait for all the files to be snapshotted?
+        # If we don't wait for snapshotting to complete, then we probably want
+        # to coalesce multiple outstanding snapshot requests for the same file,
+        # or otherwise ensure that we don't end up snapshotting an unchanged
+        # file.
+        results = []
+
+        def process(path):
+            d = self._local_snapshot_service.add_file(path)
+            d.addErrback(write_failure)
+            results.append(d)
+
+        with start_action(action_type="scanner:find-updates"):
+            yield find_updated_files(self._cooperator, self._config, process)
+            yield gatherResults(results)
+        # XXX update/use IStatus to report scan start/end
+
+
+def find_updated_files(cooperator, folder_config, on_new_file):
+    """
+    :param Cooperator cooperator: The cooperator to use to control yielding to
+        the reactor.
+    :param MagicFolderConfig folder_config: the folder for which we
+        are scanning
+
+    :param callable on_new_file: a 1-argument callable. This function
+        will be invoked for each updated / new file we find. The
+        argument will be a FilePath of the updated/new file.
+
+    :returns Deferred[None]: Deferred that fires once the scan is complete.
+    """
+    # XXX we don't handle deletes
+    def _process():
+        for path in folder_config.magic_path.asBytesMode("utf-8").walk():
+            if path.isdir():
+                continue
+            path = path.asTextMode("utf-8")
+            relpath = "/".join(path.segmentsFrom(folder_config.magic_path))
+            name = path2magic(relpath)
+            try:
+                snapshot_state = folder_config.get_currentsnapshot_pathstate(name)
+            except KeyError:
+                snapshot_state = None
+            path_state = get_pathinfo(path).state
+            if path_state != snapshot_state:
+                # TODO: We may also want to compare checksums here,
+                # to avoid `touch(1)` creating a new snapshot.
+                on_new_file(path)
+            yield
+
+    return cooperator.coiterate(_process())

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -101,6 +101,7 @@ class MagicFolderServiceTests(SyncTestCase):
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
             initial_participants=participants,
+            scanner_service=Service(),
             clock=reactor,
         )
         self.assertThat(
@@ -142,6 +143,7 @@ class MagicFolderServiceTests(SyncTestCase):
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
             initial_participants=participants,
+            scanner_service=Service(),
             clock=clock,
         )
         magic_folder.startService()
@@ -189,6 +191,7 @@ class MagicFolderServiceTests(SyncTestCase):
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
             initial_participants=participants,
+            scanner_service=Service(),
             clock=clock,
         )
         magic_folder.startService()

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -1,0 +1,208 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+"""
+Tests relating generally to magic_folder.scanner
+"""
+
+from hypothesis import given
+from testtools.matchers import Always, Equals
+from testtools.twistedsupport import succeeded
+from twisted.internet.defer import succeed
+from twisted.internet.task import Cooperator
+from twisted.python.filepath import FilePath
+
+from ..config import create_testing_configuration
+from ..magicpath import path2magic
+from ..scanner import ScannerService, find_updated_files
+from ..snapshot import RemoteSnapshot, create_local_author
+from ..util.file import PathState, get_pathinfo
+from .common import SyncTestCase
+from .strategies import relative_paths
+
+
+# This is a path state that doesn't correspond to a file written during the test.
+OLD_PATH_STATE = PathState(0, 0, 0)
+
+
+class FindUpdatesTests(SyncTestCase):
+    """
+    Tests for ``find_updated_files``
+    """
+
+    def setUp(self):
+        super(FindUpdatesTests, self).setUp()
+        self.author = create_local_author("alice")
+        self.magic_path = FilePath(self.mktemp())
+        self.magic_path.makedirs()
+        self._global_config = create_testing_configuration(
+            FilePath(self.mktemp()),
+            FilePath("dummy"),
+        )
+        self.collective_cap = "URI:DIR2:mfqwcylbmfqwcylbmfqwcylbme:mfqwcylbmfqwcylbmfqwcylbmfqwcylbmfqwcylbmfqwcylbmfqq"
+        self.personal_cap = "URI:DIR2:mjrgeytcmjrgeytcmjrgeytcmi:mjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjra"
+
+        self.config = self._global_config.create_magic_folder(
+            "default",
+            self.magic_path,
+            self.author,
+            self.collective_cap,
+            self.personal_cap,
+            1,
+        )
+        # Use a cooperator that does not cooperate.
+        self.cooperator = Cooperator(
+            terminationPredicateFactory=lambda: lambda: False,
+            scheduler=lambda f: f(),
+        )
+        self.addCleanup(self.cooperator.stop)
+
+    def setup_example(self):
+        self.magic_path.remove()
+        self.magic_path.makedirs()
+
+    @given(
+        relative_paths(),
+    )
+    def test_scan_new(self, name):
+        """
+        A completely new file is scanned
+        """
+        local = self.magic_path.preauthChild(name)
+        local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
+        local.asBytesMode("utf-8").setContent(b"dummy\n")
+
+        files = []
+        self.assertThat(
+            find_updated_files(self.cooperator, self.config, files.append),
+            succeeded(Always()),
+        )
+        self.assertThat(
+            files,
+            Equals([local]),
+        )
+
+    @given(
+        relative_paths(),
+    )
+    def test_scan_nothing(self, name):
+        """
+        An existing, non-updated file is not scanned
+        """
+        local = self.magic_path.preauthChild(name)
+        local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
+        local.asBytesMode("utf-8").setContent(b"dummy\n")
+        snap = RemoteSnapshot(
+            "new-file",
+            self.author,
+            metadata={
+                "modification_time": int(
+                    local.asBytesMode("utf-8").getModificationTime()
+                ),
+            },
+            capability="URI:DIR2-CHK:",
+            parents_raw=[],
+            content_cap="URI:CHK:",
+        )
+        self.config.store_downloaded_snapshot(
+            path2magic(name), snap, get_pathinfo(local).state
+        )
+
+        files = []
+        self.assertThat(
+            find_updated_files(self.cooperator, self.config, files.append),
+            succeeded(Always()),
+        )
+        self.assertThat(files, Equals([]))
+
+    @given(
+        relative_paths(),
+    )
+    def test_scan_something_remote(self, name):
+        """
+        We scan an update to a file we already know about.
+        """
+        local = self.magic_path.preauthChild(name)
+        local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
+        local.asBytesMode("utf-8").setContent(b"dummy\n")
+        snap = RemoteSnapshot(
+            name,
+            self.author,
+            metadata={
+                # this remote is 2min older than our local file
+                "modification_time": int(
+                    local.asBytesMode("utf-8").getModificationTime()
+                )
+                - 120,
+            },
+            capability="URI:DIR2-CHK:",
+            parents_raw=[],
+            content_cap="URI:CHK:",
+        )
+        self.config.store_downloaded_snapshot(
+            path2magic(name),
+            snap,
+            OLD_PATH_STATE,
+        )
+
+        files = []
+        self.assertThat(
+            find_updated_files(self.cooperator, self.config, files.append),
+            succeeded(Always()),
+        )
+        self.assertThat(files, Equals([local]))
+
+    @given(
+        relative_paths(),
+    )
+    def test_scan_something_local(self, name):
+        """
+        We scan an update to a file we already know about (but only locally).
+        """
+        local = self.magic_path.preauthChild("existing-file")
+        local.asBytesMode("utf-8").setContent(b"dummy\n")
+        stash_dir = FilePath(self.mktemp())
+        stash_dir.makedirs()
+
+        self.config.store_currentsnapshot_state("existing-file", OLD_PATH_STATE)
+
+        files = []
+        self.assertThat(
+            find_updated_files(self.cooperator, self.config, files.append),
+            succeeded(Always()),
+        )
+        self.assertThat(files, Equals([local]))
+
+    @given(
+        relative_paths(),
+    )
+    def test_scan_service(self, name):
+        """
+        The scanner service iteself discovers a_file
+        """
+        name = "a_file"
+        local = self.magic_path.preauthChild(name)
+        local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
+        local.asBytesMode("utf-8").setContent(b"dummy\n")
+
+        files = []
+
+        class SnapshotService(object):
+            def add_file(self, f):
+                files.append(f)
+                return succeed(None)
+
+        service = ScannerService(
+            self.config,
+            SnapshotService(),
+            object(),
+            cooperator=self.cooperator,
+        )
+        service.startService()
+        self.addCleanup(service.stopService)
+
+        self.assertThat(
+            service.scan_once(),
+            succeeded(Always()),
+        )
+
+        self.assertThat(files, Equals([local]))

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -106,6 +106,11 @@ class LocalSnapshotCreator(object):
 
         :param FilePath path: a single file inside our magic-folder dir
         """
+        # TODO: We may to have logic similar to (shared with?) the scanner,
+        # to see if we need to snapshot the file. This is probably most useful
+        # when we get here via API, rather than the scanner, but may also avoid
+        # duplicate snapshots if scanning doesn't wait for snapshotting to
+        # complete.
 
         with path.asBytesMode("utf-8").open('rb') as input_stream:
             # Query the db to check if there is an existing local

--- a/src/magic_folder/util/twisted.py
+++ b/src/magic_folder/util/twisted.py
@@ -1,0 +1,35 @@
+# Copyright (c) Least Authority TFA GmbH.
+
+"""
+Utilities for interacting with twisted.
+"""
+
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
+from functools import wraps
+
+
+def exclusively(maybe_f=None, lock_name="_lock"):
+    """
+    A method decorator that aquires a py:`DeferredLock` while running the
+    function.
+
+    :param str lock_name: The name of the lock attribute to use.
+    """
+    def wrap(f):
+        @wraps(f)
+        def wrapper(self, *args, **kwargs):
+            return getattr(self, lock_name).run(f, self, *args, **kwargs)
+
+        return wrapper
+
+    if maybe_f is None:
+        return wrap
+    else:
+        return wrap(maybe_f)


### PR DESCRIPTION
See #138.

This is the initial implementation of the scanner itself. It isn't currently hooked up to anything. There will be followups to:
- add an endpoint that will request an immediate scan ( #463)
- add configuration to scan periodically

The code for both of those is mostly written, but needs polish and tests.

I filed  #464 for adding coverage to the `@exclusively` helper.