### PR TITLE
Update HTTP API docs

### DIFF
--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -156,11 +156,11 @@ Accepts a JSON body listing the details of the participant to add::
         "author": {
             "name": "arbitrary string"
         },
-        "personal_dmd": "URI:DIR2:..."
+        "personal_dmd": "URI:DIR2-RO:..."
     }
 
 The response is delayed until the participant is correctly added to the Collective DMD.
-``personal_dmd`` is a Tahoe writable directory capability-string.
+The ``personal_dmd`` is a Tahoe read-only directory capability-string (the participant device holds the write-capability).
 A response code of **CREATED** is sent upon success with response body::
 
     {}

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -112,7 +112,7 @@ Not yet implemented.
 Get all snapshots for one folder beneath a certain path.
 
 
-``POST /v1/snapshot/<folder-name>?path=<some-path>``
+``POST /v1/magic-folder/<folder-name>/snapshot?path=<some-path>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a new snapshot for a certain file in a certain magic-folder.
@@ -127,6 +127,69 @@ The response code **CREATED** and the **Content-Type** is ``application/json``.
 The response body follows the form of this example::
 
   {}
+
+
+``GET /v1/magic-folder/<folder-name>/participants``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+List all participants in a certain magic-folder.
+
+The response is **OK** with an ``application/json`` **Content-Type**::
+
+    {
+        "participant name": {
+            "personal_dmd": "URI:DIR2-RO:..."
+        }
+    }
+
+There will be one entry per participant.
+``personal_dmd`` is a Tahoe read-only directory capability-string.
+
+
+``POST /v1/magic-folder/<folder-name>/participants``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add a new participant to a certain magic-folder.
+Accepts a JSON body listing the details of the participant to add::
+
+    {
+        "author": {
+            "name": "arbitrary string"
+        },
+        "personal_dmd": "URI:DIR2:..."
+    }
+
+The response is delayed until the participant is correctly added to the Collective DMD.
+``personal_dmd`` is a Tahoe writable directory capability-string.
+A response code of **CREATED** is sent upon success with response body::
+
+    {}
+
+
+``GET /v1/magic-folder/<folder-name>/file-status``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Retrieve the file-status of every file in a given magic-folder.
+The response is **OK** with an ``application/json`` **Content-Type**::
+
+    [
+        {
+            "relpath": "rel/path/foo",
+            "mtime": 12345,
+            "size": 321
+        },
+        {
+            "relpath": "rel/path/bar",
+            "mtime": 12346,
+            "size": 111
+        }
+    ]
+
+There will be one entry in the list for every file.
+The list is ordered from most-recent to least-recent timestamp.
+``relpath`` is the relative path in the magic-folder.
+``mtime`` is in seconds.
+``size`` is in bytes.
 
 
 Status API

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -10,7 +10,7 @@ The address of the HTTP server is part of the `daemon configuration`_.
 Authorization
 ~~~~~~~~~~~~~
 
-The HTTP API is protected by Bearer token-style authorization scheme.
+The HTTP API is protected by a Bearer token-style authorization scheme.
 Only requests which include the correct token will receive successful responses.
 Other requests will receive **401 Unauthorized** responses which omit the requested resource.
 The token value should be included with the **Bearer** scheme in the **Authorization** header element.
@@ -28,18 +28,14 @@ the client should re-read the token from the filesystem to determine if the valu
 ``GET /v1/magic-folder``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This endpoint returns a dict of all individual magic-folders managed
-by this daemon. The keys of the dict are the folder name and the
-values are themselves dicts.
+This endpoint returns a dict of all individual magic-folders managed by this daemon.
+The keys of the dict are the folder name and the values are themselves dicts.
 
-You may include the query argument ``?include_secret_information=1`` to
-include values for each folder which should be kept hidden (and are
-not shown by default). These are: ``upload_dircap``,
-``collective_dircap``, and the ``signing_key`` inside ``author``.
+You may include the query argument ``?include_secret_information=1`` to include values for each folder which should be kept hidden (and are not shown by default).
+These are: ``upload_dircap``, ``collective_dircap``, and the ``signing_key`` inside ``author``.
 
 The response code **OK** and the **Content-Type** is ``application/json``.
-The response body follows the form of this example (containing a single
-magic-folder named "documents")::
+The response body follows the form of this example (containing a single magic-folder named "documents")::
 
     {
         "documents": {
@@ -108,11 +104,13 @@ The value is a Tahoe-LAFS capability string for a stored object representing the
 Not yet implemented.
 Get all snapshots for one folder.
 
+
 ``GET /v1/snapshot/<folder-name>?path=<some-path>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Not yet implemented.
 Get all snapshots for one folder beneath a certain path.
+
 
 ``POST /v1/snapshot/<folder-name>?path=<some-path>``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -111,6 +111,10 @@ from ..web import (
     magic_folder_resource,
     APIv1,
 )
+from ..util.file import (
+    PathState,
+    seconds_to_ns,
+)
 from ..client import (
     authorized_request,
     url_to_bytes,
@@ -1413,7 +1417,6 @@ class FileStatusTests(SyncTestCase):
             start_folder_services=False,
         )
         mf_config = node.global_config.get_magic_folder("default")
-        from ..util.file import PathState, seconds_to_ns
         mf_config.store_currentsnapshot_state(
             "foo",
             PathState(123, seconds_to_ns(1), seconds_to_ns(2)),

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -442,7 +442,7 @@ class APIv1(object):
 
         return json.dumps([
             {
-                "name": name,
+                "relpath": magic2path(name),
                 "mtime": ns_to_seconds(ps.mtime_ns),
                 "size": ps.size,
             }


### PR DESCRIPTION
Fixes #480 
Several HTTP APIs were undocumented.

The (new) `file-status` API should (and now does) emit relative-paths.