### PR TITLE
Improve the reporting of integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
       - run: &SUBMIT_COVERAGE
           name: "Submit coverage results"
           command: |
-            /tmp/venv/bin/codecov
+            /tmp/venv/bin/codecov --flags unit-test
 
 
   debian-9:
@@ -284,6 +284,10 @@ jobs:
       - run: *RUN_TESTS
       - store_test_results:
           path: "junit/"
+      - run:
+          name: "Submit coverage results"
+          command: |
+            /tmp/venv/bin/codecov --flags integration
 
   integration-1.14:
     <<: *INTEGRATION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,8 @@ jobs:
       - run: *RUN_TESTS
       - store_test_results:
           path: "junit/"
+      - store_artifacts: *STORE_ELIOT_LOG
+      - store_artifacts: *STORE_OTHER_ARTIFACTS
       - run:
           name: "Submit coverage results"
           command: |

--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -74,19 +74,28 @@ else
     alternative="false"
 fi
 
+# Post-process the eliot logs, even if the test suite fail.  We do this by
+# running this function before exiting, even if a command fails.
+process_eliot_logs() {
+   if [[ -n "${ARTIFACTS}" && -f "${PROJECT_ROOT}/eliot.log" ]]; then
+        "${BOOTSTRAP_VENV}"/bin/eliot-prettyprint < "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot.txt
+        "${BOOTSTRAP_VENV}"/bin/eliot-tree --field-limit=0 "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot-tree.txt
+   fi
+}
+
+trap 'process_eliot_logs' EXIT
+
 ${TIMEOUT} "${BOOTSTRAP_VENV}"/bin/tox \
     -c "${PROJECT_ROOT}"/tox.ini \
     --workdir /tmp/magic-folder.tox \
     -e "${MAGIC_FOLDER_TOX_ENVIRONMENT}" \
     ${MAGIC_FOLDER_TOX_ARGS} || "${alternative}"
 
-if [ -n "${ARTIFACTS}" ]; then
-    if [ -f "${PROJECT_ROOT}/eliot.log" ]; then
-        "${BOOTSTRAP_VENV}"/bin/eliot-prettyprint < "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot.txt
-        "${BOOTSTRAP_VENV}"/bin/eliot-tree --field-limit=0 "${PROJECT_ROOT}"/eliot.log > "${ARTIFACTS}"/eliot-tree.txt
-    fi
-
-    if [ -f "${SUBUNIT2}" ]; then
+if [[ -n "${ARTIFACTS}" ]]; then
+    # Twisted trial's subunit reporter causes the trial process to exit with 0, even if the
+    # test suite failed. The expectation is that a later process will read the result stream
+    # and report the failure. Thus, we will get here even if the test suite fails.
+    if [[ -f "${SUBUNIT2}" ]]; then
         # Create a junitxml results area.
         mkdir -p "$(dirname "${JUNITXML}")"
         "${BOOTSTRAP_VENV}"/bin/subunit2junitxml < "${SUBUNIT2}" > "${JUNITXML}" || "${alternative}"

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -39,7 +39,9 @@ jobs:
     - name: Generate eliot-tree.
       if: ${{ always() }}
       run: |
-        eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
+        if [[ -f eliot.log ]]; then
+            eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
+        fi
 
     - name: Upload eliot.log in case of failure
       uses: "actions/upload-artifact@v2"
@@ -82,7 +84,9 @@ jobs:
     - name: Generate eliot-tree.
       if: ${{ always() }}
       run: |
-        eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
+        if [[ -f eliot.log ]]; then
+            eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
+        fi
 
     - name: Upload eliot.log in case of failure
       uses: "actions/upload-artifact@v2"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel tox
+        pip install wheel tox eliot-tree
 
     - name: Test with tox
       run: tox -e py27-coverage
@@ -61,12 +61,20 @@ jobs:
         MAGIC_FOLDER_HYPOTHESIS_PROFILE: "magic-folder-ci"
         PIP_FIND_LINKS: ./wheelhouse
 
+    - name: Generate eliot-tree.
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        if [[ -f eliot.log ]]; then
+            eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
+        fi
+
     - name: Upload eliot.log in case of failure
       uses: "actions/upload-artifact@v2"
       with:
         if-no-files-found: "warn"
-        name: "eliot.log"
-        path: "eliot.log"
+        name: "unit-test"
+        path: "eliot*"
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,3 +81,79 @@ jobs:
       with:
         token: "322d708d-8283-4827-b605-ccf02bfecf70"
         file: "./coverage.xml"
+
+  integration-tests:
+
+    runs-on: "windows-latest"
+    strategy:
+      matrix:
+        python-version:
+          - "2.7"
+
+    steps:
+    - name: Check out source code
+      uses: actions/checkout@v2
+      with:
+        # Get enough history for the tags we get next to be meaningful.  0
+        # means all history.
+        fetch-depth: "0"
+    # Get tags not fetched by the checkout action, needed for auto-versioning.
+    - run: "git fetch origin +refs/tags/*:refs/tags/*"
+
+    # Get MS VC++ 9 aka Visual Studio 2008, required to build Python 2.7
+    # extensions (zfec via Tahoe-LAFS).
+    - name: Build local chocloatey package for MSVC 9.0 for Python 2.7
+      uses: "crazy-max/ghaction-chocolatey@v1"
+      with:
+        args: "pack .github/vcpython27/vcpython27.nuspec"
+
+    - name: Install MSVC 9.0 for Python 2.7
+      uses: "crazy-max/ghaction-chocolatey@v1"
+      with:
+        args: "install --source=.;https://chocolatey.org/api/v2/ vcpython27"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Use pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel tox eliot-tree
+
+    - name: Test with tox
+      continue-on-error: true
+      run: tox -e integration
+      env:
+        PIP_FIND_LINKS: ./wheelhouse
+
+    - name: Generate eliot-tree.
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        if [[ -f eliot.log ]]; then
+            eliot-tree --field-limit=0 eliot.log > eliot-tree.txt
+        fi
+
+    - name: Upload eliot.log in case of failure
+      uses: "actions/upload-artifact@v2"
+      if: ${{ always() }}
+      with:
+        if-no-files-found: "warn"
+        name: "integration"
+        path: "eliot*"
+
+    - uses: codecov/codecov-action@v1
+      with:
+        token: "322d708d-8283-4827-b605-ccf02bfecf70"
+        file: "./coverage.xml"
+        flags: "integration"


### PR DESCRIPTION
Fixes #482.

- Capture coverage information from *all* integration tests, instead of just macOS.
- Capture eliot logs from integration tests.
- Turn on windows integration tests. (When I first enabled windows tests in CI, the integration tests seemed to be timing out; that is no longer the case).


I've found myself needing to add these changes to branches to debug things from CI, or re-run the tests locally.
