### PR TITLE
Move tahoe-using logic out of the web service.

### DIFF
--- a/src/magic_folder/client.py
+++ b/src/magic_folder/client.py
@@ -250,7 +250,7 @@ def create_http_client(reactor, api_client_endpoint_str):
 
 # See https://github.com/LeastAuthority/magic-folder/issues/280
 # global_service should expect/demand an Interface
-def create_testing_http_client(reactor, config, global_service, get_api_token, tahoe_client, status_service):
+def create_testing_http_client(reactor, config, global_service, get_api_token, status_service):
     """
     :param global_service: an object providing the API of the global
         magic-folder service
@@ -264,7 +264,7 @@ def create_testing_http_client(reactor, config, global_service, get_api_token, t
         in-memory objects. These objects obtain their data from the
         service provided
     """
-    v1_resource = APIv1(config, global_service, status_service, tahoe_client).app.resource()
+    v1_resource = APIv1(config, global_service, status_service).app.resource()
     root = magic_folder_resource(get_api_token, v1_resource)
     client = HTTPClient(
         agent=RequestTraversalAgent(root),

--- a/src/magic_folder/magic_folder.py
+++ b/src/magic_folder/magic_folder.py
@@ -7,9 +7,11 @@ from __future__ import (
 
 import six
 
-from twisted.python.filepath import FilePath
+from twisted.python.filepath import FilePath, InsecurePath
 from twisted.internet import defer
+from twisted.internet.defer import Deferred
 from twisted.application import service
+from twisted.web import http
 
 from eliot import (
     Field,
@@ -17,6 +19,7 @@ from eliot import (
     MessageType,
 )
 
+from .common import APIError
 from .util.eliotutil import (
     RELPATH,
     validateSetMembership,
@@ -36,6 +39,7 @@ from .downloader import (
     LocalMagicFolderFilesystem,
 )
 from .participants import (
+    IParticipant,
     participants_from_collective,
 )
 from .scanner import (
@@ -185,6 +189,36 @@ class MagicFolder(service.MultiService):
             been snapshotted.
         """
         return self.scanner_service.scan_once()
+
+    def participants(self):
+        # type: () -> Deferred[list[IParticipant]]
+        """
+        List all participants of this folder
+        """
+        return self._participants.list()
+
+    def add_participant(self, author, participant_directory):
+        return self._participants.add(author, participant_directory)
+
+    def add_snapshot(self, relative_path):
+        # type: (unicode) -> Deferred[None]
+        """
+        Create a new snapshot of the given file.
+        """
+
+        # preauthChild allows path-separators in the "path" (i.e. not
+        # just a single path-segment). That is precisely what we want
+        # here, though. It sill does not allow the path to "jump out"
+        # of the base magic_path -- that is, an InsecurePath error
+        # will result if you pass an absolute path outside the folder
+        # or a relative path that reaches up too far.
+        try:
+            path = self.config.magic_path.preauthChild(relative_path)
+        except InsecurePath as e:
+            return defer.fail(
+                APIError.from_exception(http.NOT_ACCEPTABLE, e)
+            )
+        return self.local_snapshot_service.add_file(path)
 
 
 _NICKNAME = Field.for_types(

--- a/src/magic_folder/service.py
+++ b/src/magic_folder/service.py
@@ -79,7 +79,6 @@ class MagicFolderService(MultiService):
             self.config,
             self,
             self._get_auth_token,
-            self.tahoe_client,
             self.status_service,
         )
         web_service.setServiceParent(self)

--- a/src/magic_folder/test/cli/test_magic_folder.py
+++ b/src/magic_folder/test/cli/test_magic_folder.py
@@ -124,7 +124,6 @@ class ListMagicFolder(AsyncTestCase):
             self.config,
             global_service,
             lambda: self.config.api_token,
-            tahoe_client,
             status_service,
         )
 
@@ -245,7 +244,6 @@ class CreateMagicFolder(AsyncTestCase):
             self.config,
             folder_service,
             lambda: self.config.api_token,
-            tahoe_client,
             status_service,
         )
 

--- a/src/magic_folder/test/fixtures.py
+++ b/src/magic_folder/test/fixtures.py
@@ -325,7 +325,7 @@ class MagicFolderNode(object):
             for name in folders:
                 global_service.get_folder_service(name).startService()
 
-        http_client = create_testing_http_client(reactor, global_config, global_service, lambda: auth_token, tahoe_client, status_service)
+        http_client = create_testing_http_client(reactor, global_config, global_service, lambda: auth_token, status_service)
 
         return cls(
             tahoe_root=tahoe_root,

--- a/src/magic_folder/test/matchers.py
+++ b/src/magic_folder/test/matchers.py
@@ -182,3 +182,16 @@ def matches_flushed_traceback(exception, value_re=None):
     return AfterPreprocessing(
         as_exc_info_tuple, MatchesException(exception, value_re=value_re)
     )
+
+def matches_failure(exception, value_re=None):
+    """
+    Matches an twisted :py:`Failure` with the given exception.
+
+    See :py:`testtools.matches.MatchesException`.
+    """
+    def as_exc_info_tuple(failure):
+        return failure.type, failure.value, failure.tb
+
+    return AfterPreprocessing(
+        as_exc_info_tuple, MatchesException(exception, value_re=value_re)
+    )

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -1186,9 +1186,10 @@ class CreateSnapshotTests(SyncTestCase):
             ),
             succeeded(
                 matches_response(
-                    # Maybe this could be BAD_REQUEST instead, sometimes, if
-                    # the path argument was bogus somehow.
-                    code_matcher=Equals(INTERNAL_SERVER_ERROR),
+                    # Maybe this could be BAD_REQUEST or INTERNAL_SERVER_ERROR
+                    # instead, sometimes, if the path argument was bogus or
+                    # somehow the path could not be read.
+                    code_matcher=Equals(NOT_ACCEPTABLE),
                     headers_matcher=header_contains({
                         u"Content-Type": Equals([u"application/json"]),
                     }),

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -400,12 +400,7 @@ class APIv1(object):
             _application_json(request)
             returnValue(json.dumps({u"reason": str(e)}))
 
-        try:
-            yield folder_service.local_snapshot_service.add_file(path)
-        except Exception as e:
-            request.setResponseCode(http.INTERNAL_SERVER_ERROR)
-            _application_json(request)
-            returnValue(json.dumps({u"reason": str(e)}))
+        yield folder_service.local_snapshot_service.add_file(path)
 
         request.setResponseCode(http.CREATED)
         _application_json(request)

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -167,7 +167,6 @@ class APIv1(object):
     _global_config = attr.ib()
     _global_service = attr.ib()
     _status_service = attr.ib(validator=attr.validators.provides(IStatus))
-    _tahoe_client = attr.ib()
 
     app = Klein()
 
@@ -558,7 +557,7 @@ def unauthorized(request):
     return b""
 
 
-def magic_folder_web_service(web_endpoint, global_config, global_service, get_auth_token, tahoe_client, status_service):
+def magic_folder_web_service(web_endpoint, global_config, global_service, get_auth_token, status_service):
     """
     :param web_endpoint: a IStreamServerEndpoint where we should listen
 
@@ -567,13 +566,11 @@ def magic_folder_web_service(web_endpoint, global_config, global_service, get_au
 
     :param get_auth_token: a callable that returns the current authentication token
 
-    :param TahoeClient tahoe_client: a way to access Tahoe-LAFS
-
     :param IStatus status_service: our status reporting service
 
     :returns: a StreamServerEndpointService instance
     """
-    v1_resource = APIv1(global_config, global_service, status_service, tahoe_client).app.resource()
+    v1_resource = APIv1(global_config, global_service, status_service).app.resource()
     root = magic_folder_resource(get_auth_token, v1_resource)
     return StreamServerEndpointService(
         web_endpoint,


### PR DESCRIPTION
Fixes #486.

This moves all the business logic involving tahoe out from the web service. In particular, it makes the web service avoid creating an `IParticipants` itself, so that error handling for #420 doesn't need to be duplicated there.