### PR TITLE
Use `magic_folder.util.capabilities` everywhere.

### DIFF
--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -78,10 +78,6 @@ from zope.interface import (
     Interface,
 )
 
-from allmydata.uri import (
-    from_string as tahoe_uri_from_string,
-)
-
 from .snapshot import (
     LocalAuthor,
     LocalSnapshot,
@@ -106,6 +102,7 @@ from eliot import (
     Field,
 )
 
+from .util.capabilities import is_readonly_directory_cap
 from .util.eliotutil import (
     RELPATH,
     validateSetMembership,
@@ -1210,10 +1207,7 @@ class MagicFolderConfig(object):
             if the collective capability we have is mutable.
         """
         # check if this folder has a writable collective dircap
-        collective_dmd = tahoe_uri_from_string(
-            self.collective_dircap.encode("utf8")
-        )
-        return not collective_dmd.is_readonly()
+        return not is_readonly_directory_cap(self.collective_dircap)
 
 
 class ITokenProvider(Interface):

--- a/src/magic_folder/service.py
+++ b/src/magic_folder/service.py
@@ -20,7 +20,7 @@ from .magic_folder import MagicFolder
 from .snapshot import create_local_author
 from .status import IStatus, WebSocketStatusService
 from .tahoe_client import create_tahoe_client
-from .util.capabilities import tahoe_uri_from_string
+from .util.capabilities import to_readonly_capability
 from .web import magic_folder_web_service
 
 
@@ -231,7 +231,7 @@ class MagicFolderService(MultiService):
         personal_write_cap = yield self.tahoe_client.create_mutable_directory()
 
         # 'attenuate' our personal dmd write-cap to a read-cap
-        personal_readonly_cap = tahoe_uri_from_string(personal_write_cap).get_readonly().to_string().encode("ascii")
+        personal_readonly_cap = to_readonly_capability(personal_write_cap)
 
         # add ourselves to the collective
         yield self.tahoe_client.add_entry_to_mutable_directory(

--- a/src/magic_folder/test/test_strategies.py
+++ b/src/magic_folder/test/test_strategies.py
@@ -16,10 +16,6 @@ from hypothesis import (
     assume,
 )
 
-from allmydata.uri import (
-    from_string as cap_from_string,
-)
-
 from testtools.matchers import (
     Equals,
 )
@@ -28,6 +24,7 @@ from twisted.python.filepath import (
     FilePath,
 )
 
+from ..util.capabilities import tahoe_uri_from_string
 from .common import (
     SyncTestCase,
 )
@@ -48,7 +45,7 @@ class StrategyTests(SyncTestCase):
         Values built by ``tahoe_lafs_chk_capabilities`` round-trip through ASCII
         and ``allmydata.uri.from_string`` and their ``to_string`` method.
         """
-        cap = cap_from_string(cap_text.encode("ascii"))
+        cap = tahoe_uri_from_string(cap_text.encode("ascii"))
         serialized = cap.to_string().decode("ascii")
         self.assertThat(
             cap_text,
@@ -61,7 +58,7 @@ class StrategyTests(SyncTestCase):
         Values built by ``tahoe_lafs_dir_capabilities`` round-trip through ASCII
         and ``allmydata.uri.from_string`` and their ``to_string`` method.
         """
-        cap = cap_from_string(cap_text.encode("ascii"))
+        cap = tahoe_uri_from_string(cap_text.encode("ascii"))
         serialized = cap.to_string().decode("ascii")
         self.assertThat(
             cap_text,

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -1160,7 +1160,7 @@ class ParticipantsTests(SyncTestCase):
                     code_matcher=Equals(BAD_REQUEST),
                     body_matcher=AfterPreprocessing(
                         loads,
-                        Equals({"reason": "personal_dmd must be a directory-capability"})
+                        Equals({"reason": "personal_dmd must be a read-only directory capability."})
                     )
                 )
             )
@@ -1209,7 +1209,7 @@ class ParticipantsTests(SyncTestCase):
                     code_matcher=Equals(BAD_REQUEST),
                     body_matcher=AfterPreprocessing(
                         loads,
-                        Equals({"reason": "personal_dmd must be read-only"})
+                        Equals({"reason": "personal_dmd must be a read-only directory capability."})
                     )
                 )
             )

--- a/src/magic_folder/util/capabilities.py
+++ b/src/magic_folder/util/capabilities.py
@@ -1,25 +1,18 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
-
-from __future__ import (
-    print_function,
-    unicode_literals,
-)
-
 """
 Utilities for interacting with Tahoe capability-strings
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from allmydata.uri import (
-    from_string as tahoe_uri_from_string,
+    IDirectoryURI,
     IDirnodeURI,
     IFileURI,
     IImmutableFileURI,
+    IReadonlyDirectoryURI,
+    IVerifierURI,
 )
+from allmydata.uri import from_string as tahoe_uri_from_string
 
 
 def is_directory_cap(capability):
@@ -40,6 +33,37 @@ def is_file_cap(capability):
     return IFileURI.providedBy(uri) or IImmutableFileURI.providedBy(uri)
 
 
+def is_immutable_directory_cap(capability):
+    """
+    :returns bool: True if `capability` is an immmutable directory capability
+        (note this excludes all kinds of "verify" capabilities).
+    """
+    uri = tahoe_uri_from_string(capability)
+    return (
+        IDirnodeURI.providedBy(uri)
+        and not uri.is_mutable()
+        and not IVerifierURI.providedBy(uri)
+    )
+
+
+def is_mutable_directory_cap(capability):
+    """
+    :returns bool: True if `capability` is a mutable directory capability
+        (note this excludes all kinds of "verify" capabilities).
+    """
+    uri = tahoe_uri_from_string(capability)
+    return IDirectoryURI.providedBy(uri)
+
+
+def is_readonly_directory_cap(capability):
+    """
+    :returns bool: True if `capability` is a read-only directory capability
+        (note this excludes all kinds of "verify" capabilities).
+    """
+    uri = tahoe_uri_from_string(capability)
+    return IReadonlyDirectoryURI.providedBy(uri)
+
+
 def to_readonly_capability(capability):
     """
     Converts a capability-string to a readonly capability-string. This
@@ -49,3 +73,10 @@ def to_readonly_capability(capability):
     if cap.is_readonly():
         return capability
     return cap.get_readonly().to_string()
+
+
+def to_verify_capability(capability):
+    """
+    Converts a capability-string to a verify capability-string.
+    """
+    return tahoe_uri_from_string(capability).get_verify_cap().to_string()

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -53,12 +53,6 @@ from werkzeug.routing import RequestRedirect
 
 from klein import Klein
 
-from allmydata.uri import (
-    from_string as tahoe_uri_from_string,
-)
-from allmydata.interfaces import (
-    IDirnodeURI,
-)
 from cryptography.hazmat.primitives.constant_time import bytes_eq as timing_safe_compare
 
 from .common import APIError
@@ -75,6 +69,7 @@ from .snapshot import (
 from .participants import (
     participants_from_collective,
 )
+from .util.capabilities import is_readonly_directory_cap
 from .util.file import (
     ns_to_seconds,
 )
@@ -330,12 +325,10 @@ class APIv1(object):
             VerifyKey(os.urandom(32)),
         )
 
-        dmd = tahoe_uri_from_string(participant["personal_dmd"])
-        if not IDirnodeURI.providedBy(dmd):
-            raise _InputError("personal_dmd must be a directory-capability")
-        if not dmd.is_readonly():
-            raise _InputError("personal_dmd must be read-only")
         personal_dmd_cap = participant["personal_dmd"]
+        if not is_readonly_directory_cap(personal_dmd_cap):
+            raise _InputError("personal_dmd must be a read-only directory capability.")
+
 
         collective = participants_from_collective(
             folder_config.collective_dircap,


### PR DESCRIPTION
While working on #420, I went updated all the direct uses of `allmydata.uri` to use our wrappers instead.

I left the use in `magic_folders.testing.web` (and it's tests), as the code is currently shared with tahoe-lafs. I also left some dead uses in `magic_folder.test.common`, which I'll remove, with a bunch of other dead code in a separate PR.