### PR TITLE
Stop using mangled paths, except for tahoe directory entries.

### DIFF
--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -157,7 +157,7 @@ _magicfolder_config_schema = Schema([
             -- A random, unique identifier for this particular snapshot.
             [identifier]       TEXT PRIMARY KEY,
 
-            -- The magicpath-mangled name of the file this snapshot is for,
+            -- The relative path of the file this snapshot is for,
             -- UTF-8-encoded.
             [name]             TEXT,
 
@@ -845,7 +845,7 @@ class MagicFolderConfig(object):
 
         :raise KeyError: If there is no matching snapshot for the given path.
 
-        :returns: An instance of LocalSnapshot for the given magicpath.
+        :returns: An instance of LocalSnapshot for the given path.
         """
         # Read all the state for this name from the database.
         snapshots = _get_snapshots(cursor, name)

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -52,9 +52,6 @@ from twisted.internet.interfaces import (
 from .config import (
     MagicFolderConfig,
 )
-from .magicpath import (
-    path2magic,
-)
 from .participants import IWriteableParticipant
 from .snapshot import (
     create_snapshot_from_capability,
@@ -690,7 +687,7 @@ class DownloaderService(service.MultiService):
             # latest, there is nothing to do .. otherwise, we
             # have to figure out what to do
             try:
-                our_snapshot_cap = self._config.get_remotesnapshot(path2magic(relpath))
+                our_snapshot_cap = self._config.get_remotesnapshot(relpath)
             except KeyError:
                 our_snapshot_cap = None
             if snapshot.capability != our_snapshot_cap:

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -55,6 +55,7 @@ from .config import (
 from .magicpath import (
     path2magic,
 )
+from .participants import IWriteableParticipant
 from .snapshot import (
     create_snapshot_from_capability,
 )
@@ -275,6 +276,7 @@ class MagicFolderUpdater(object):
     _remote_cache = attr.ib(validator=instance_of(RemoteSnapshotCacheService))
     tahoe_client = attr.ib() # validator=instance_of(TahoeClient))
     _status = attr.ib(validator=attr.validators.instance_of(FolderStatus))
+    _write_participant = attr.ib(validator=provides(IWriteableParticipant))
     _lock = attr.ib(init=False, factory=DeferredLock)
 
     @exclusively
@@ -440,11 +442,9 @@ class MagicFolderUpdater(object):
                     # the Personal DMD are reconciled .. that is, if we crash
                     # here and/or can't update our Personal DMD we need to
                     # retry later.
-                    yield self.tahoe_client.add_entry_to_mutable_directory(
-                        self._config.upload_dircap,
+                    yield self._write_participant.update_snapshot(
                         relpath,
                         snapshot.capability.encode("ascii"),
-                        replace=True,
                     )
 
 

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -668,12 +668,9 @@ class DownloaderService(service.MultiService):
                     if participant.is_self:
                         # we don't download from ourselves
                         continue
-                    files = yield self._tahoe_client.list_directory(participant.dircap)
-                    for fname, data in files.items():
-                        snapshot_cap, metadata = data
-                        fpath = self._config.magic_path.preauthChild(magic2path(fname))
-                        relpath = "/".join(fpath.segmentsFrom(self._config.magic_path))
-                        yield self._process_snapshot(snapshot_cap, relpath)
+                    files = yield participant.files()
+                    for relpath, file_data in files.items():
+                        yield self._process_snapshot(file_data.snapshot_cap, relpath)
 
     @inline_callbacks
     def _process_snapshot(self, snapshot_cap, relpath):

--- a/src/magic_folder/participants.py
+++ b/src/magic_folder/participants.py
@@ -30,6 +30,7 @@ from eliot.twisted import (
 
 from .magicpath import (
     magic2path,
+    path2magic,
 )
 from .snapshot import (
     RemoteAuthor,
@@ -314,7 +315,7 @@ class _WriteableParticipant(object):
         """
         return self._tahoe_client.add_entry_to_mutable_directory(
             self.upload_cap.encode("ascii"),
-            name,
+            path2magic(name),
             capability.encode("ascii"),
             replace=True,
         )

--- a/src/magic_folder/participants.py
+++ b/src/magic_folder/participants.py
@@ -250,31 +250,30 @@ class _CollectiveDirnodeParticipant(object):
     @inline_callbacks
     def files(self):
         """
-        List the children of the directory node, decode their paths, and return a
+        List the snapshots of this participant, decode their paths, and return a
         Deferred which fires with a dictionary mapping all of the paths to
         more details.
         """
         result = yield self._tahoe_client.list_directory(self.dircap)
         returnValue({
-            magic2path(encoded_relpath_u): FolderFile(child, metadata)
+            magic2path(encoded_relpath_u): SnapshotEntry(child, metadata)
             for (encoded_relpath_u, (child, metadata))
             in result.items()
         })
 
 
 @attr.s
-class FolderFile(object):
+class SnapshotEntry(object):
     """
     A file associated with some metadata in a particular container (such as a
     Tahoe-LAFS directory node).
 
-    :ivar allmydata.interfaces.IFilesystemNode node: The Tahoe-LAFS node for
-        the underlying file content.
+    :ivar unicode snapshot_cap: The capability for the underlying snapshot
 
     :ivar dict metadata: Metadata associated with the file content in the
         containing directory.
     """
-    node = attr.ib()
+    snapshot_cap = attr.ib()
     metadata = attr.ib()
 
     @property

--- a/src/magic_folder/scanner.py
+++ b/src/magic_folder/scanner.py
@@ -14,7 +14,6 @@ from twisted.application.service import MultiService
 from twisted.internet.defer import DeferredLock, gatherResults
 from twisted.internet.task import Cooperator
 
-from .magicpath import path2magic
 from .util.file import get_pathinfo
 from .util.twisted import exclusively
 
@@ -140,7 +139,6 @@ def find_updated_files(cooperator, folder_config, on_new_file, status):
     def process_file(path):
         with action.context():
             relpath = "/".join(path.segmentsFrom(magic_path))
-            mangled_name = path2magic(relpath)
             with start_action(action_type="scanner:find-updates:file", relpath=relpath):
                 # NOTE: Make sure that we get both these states without yielding
                 # to the reactor. Otherwise, we may detect a changed made by us
@@ -148,7 +146,7 @@ def find_updated_files(cooperator, folder_config, on_new_file, status):
                 path_info = get_pathinfo(path)
                 try:
                     snapshot_state = folder_config.get_currentsnapshot_pathstate(
-                        mangled_name
+                        relpath
                     )
                 except KeyError:
                     snapshot_state = None

--- a/src/magic_folder/test/fixtures.py
+++ b/src/magic_folder/test/fixtures.py
@@ -48,6 +48,7 @@ from ..tahoe_client import (
 from ..magic_folder import (
     RemoteSnapshotCreator,
 )
+from ..participants import participants_from_collective
 from ..snapshot import create_local_author
 from ..status import (
     WebSocketStatusService,
@@ -175,13 +176,18 @@ class RemoteSnapshotCreatorFixture(Fixture):
         self.poll_interval = 1
         self.scan_interval = None
 
+        collective_dircap = u"URI:DIR2-RO:mjrgeytcmjrgeytcmjrgeytcmi:mjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjra"
+        participants = participants_from_collective(
+            collective_dircap, self.upload_dircap, self.tahoe_client
+        )
+
         self.config = MagicFolderConfig.initialize(
             u"some-folder",
             SQLite3DatabaseLocation.memory(),
             self.author,
             self.stash_path,
-            u"URI:DIR2-RO:aaa:bbb",
-            u"URI:DIR2:ccc:ddd",
+            u"URI:DIR2-RO:mjrgeytcmjrgeytcmjrgeytcmi:mjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjra",
+            self.upload_dircap,
             self.magic_path,
             self.poll_interval,
             self.scan_interval,
@@ -196,8 +202,8 @@ class RemoteSnapshotCreatorFixture(Fixture):
             config=self.config,
             local_author=self.author,
             tahoe_client=self.tahoe_client,
-            upload_dircap=self.upload_dircap,
             status=FolderStatus(self.config.name, self.status),
+            write_participant=participants.writer,
         )
 
 @attr.s

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -242,7 +242,7 @@ def tahoe_lafs_dir_capabilities():
     Build unicode strings which look like Tahoe-LAFS directory capability strings.
     """
     return builds(
-        lambda a, b: u"URI:DIR2:{}:{}".format(base32.b2a(a), base32.b2a(b)),
+        lambda a, b: b"URI:DIR2:{}:{}".format(base32.b2a(a), base32.b2a(b)),
         binary(min_size=16, max_size=16),
 
         binary(min_size=32, max_size=32),

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -677,8 +677,8 @@ class ConflictTests(AsyncTestCase):
             FilePath("dummy"),
         )
 
-        self.alice_collective = "URI:DIR2:"
-        self.alice_personal = "URI:DIR2:"
+        self.alice_collective = b"URI:DIR2:mjrgeytcmjrgeytcmjrgeytcmi:mjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjra"
+        self.alice_personal = b"URI:DIR2:mjrgeytcmjrgeytcmjrgeytcmi:mjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjrgeytcmjra"
 
         self.alice_config = self._global_config.create_magic_folder(
             "default",
@@ -702,17 +702,22 @@ class ConflictTests(AsyncTestCase):
             self.tahoe_calls.append((method, url, params, headers, data))
             return (200, {}, b"{}")
 
+        tahoe_client = create_tahoe_client(
+            DecodedURL.from_text(u"http://invalid./"),
+            StubTreq(StringStubbingResource(get_resource_for)),
+        )
+        particiapnts = participants_from_collective(
+            self.alice_collective, self.alice_personal, tahoe_client
+        )
         self.status = WebSocketStatusService(reactor, self._global_config)
         self.updater = MagicFolderUpdater(
             clock=Clock(),
             magic_fs=self.filesystem,
             config=self.alice_config,
             remote_cache=self.remote_cache,
-            tahoe_client=create_tahoe_client(
-                DecodedURL.from_text(u"http://invalid./"),
-                StubTreq(StringStubbingResource(get_resource_for)),
-            ),
+            tahoe_client=tahoe_client,
             status=FolderStatus(self.alice_config.name, self.status),
+            write_participant=particiapnts.writer,
         )
 
     @inline_callbacks

--- a/src/magic_folder/test/test_local_snapshot.py
+++ b/src/magic_folder/test/test_local_snapshot.py
@@ -51,9 +51,6 @@ from ..magic_folder import (
 from ..snapshot import (
     create_local_author,
 )
-from ..magicpath import (
-    path2magic,
-)
 from ..config import (
     create_global_configuration,
     create_testing_configuration,
@@ -325,10 +322,9 @@ class LocalSnapshotCreatorTests(SyncTestCase):
 
         self.assertThat(self.db.get_all_localsnapshot_paths(), HasLength(len(files)))
         for (file, filename, content) in files:
-            mangled_filename = path2magic(filename)
-            stored_snapshot = self.db.get_local_snapshot(mangled_filename)
+            stored_snapshot = self.db.get_local_snapshot(filename)
             stored_content = stored_snapshot.content_path.getContent()
-            path_state = self.db.get_currentsnapshot_pathstate(mangled_filename)
+            path_state = self.db.get_currentsnapshot_pathstate(filename)
             self.assertThat(stored_content, Equals(content))
             self.assertThat(stored_snapshot.parents_local, HasLength(0))
             self.assertThat(
@@ -357,8 +353,7 @@ class LocalSnapshotCreatorTests(SyncTestCase):
             succeeded(Always()),
         )
 
-        foo_magicname = path2magic(filename)
-        stored_snapshot1 = self.db.get_local_snapshot(foo_magicname)
+        stored_snapshot1 = self.db.get_local_snapshot(filename)
 
         # now modify the file with some new content.
         foo.asBytesMode("utf-8").setContent(content2)
@@ -368,7 +363,7 @@ class LocalSnapshotCreatorTests(SyncTestCase):
             self.snapshot_creator.store_local_snapshot(foo),
             succeeded(Always()),
         )
-        stored_snapshot2 = self.db.get_local_snapshot(foo_magicname)
+        stored_snapshot2 = self.db.get_local_snapshot(filename)
 
         self.assertThat(
             stored_snapshot2.parents_local[0],

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -108,7 +108,7 @@ class MagicFolderServiceTests(SyncTestCase):
             folder_status=FolderStatus(name, status_service),
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
-            initial_participants=participants,
+            participants=participants,
             scanner_service=Service(),
             clock=reactor,
         )
@@ -169,7 +169,7 @@ class MagicFolderServiceTests(SyncTestCase):
             folder_status=folder_status,
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
-            initial_participants=participants,
+            participants=participants,
             scanner_service=Service(),
             clock=clock,
         )
@@ -235,7 +235,7 @@ class MagicFolderServiceTests(SyncTestCase):
             folder_status=folder_status,
             remote_snapshot_cache=Service(),
             downloader=MultiService(),
-            initial_participants=participants,
+            participants=participants,
             scanner_service=Service(),
             clock=clock,
         )

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -19,7 +19,6 @@ from twisted.python import runtime
 from twisted.python.filepath import FilePath
 
 from ..config import create_testing_configuration
-from ..magicpath import path2magic
 from ..scanner import ScannerService, find_updated_files
 from ..snapshot import RemoteSnapshot, create_local_author
 from ..status import FolderStatus, WebSocketStatusService
@@ -139,7 +138,7 @@ class FindUpdatesTests(SyncTestCase):
             content_cap="URI:CHK:",
         )
         self.config.store_downloaded_snapshot(
-            path2magic(name), snap, get_pathinfo(local).state
+            name, snap, get_pathinfo(local).state
         )
 
         files = []
@@ -176,7 +175,7 @@ class FindUpdatesTests(SyncTestCase):
             content_cap="URI:CHK:",
         )
         self.config.store_downloaded_snapshot(
-            path2magic(name),
+            name,
             snap,
             OLD_PATH_STATE,
         )

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -121,7 +121,6 @@ from ..client import (
     authorized_request,
     url_to_bytes,
 )
-from ..magicpath import path2magic
 from .strategies import (
     tahoe_lafs_readonly_dir_capabilities,
     tahoe_lafs_dir_capabilities,
@@ -1024,7 +1023,7 @@ class ScanFolderTests(SyncTestCase):
         snapshot_paths = folder_config.get_all_localsnapshot_paths()
         self.assertThat(
             snapshot_paths,
-            Equals({path2magic(path_in_folder)}),
+            Equals({path_in_folder}),
         )
 
     def test_snapshot_no_folder(self):

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -53,6 +53,7 @@ from .magicpath import (
     magic2path,
     path2magic,
 )
+from .participants import IWriteableParticipant
 from .util.file import get_pathinfo
 
 
@@ -275,7 +276,7 @@ class RemoteSnapshotCreator(object):
     _config = attr.ib(validator=attr.validators.instance_of(MagicFolderConfig))
     _local_author = attr.ib()
     _tahoe_client = attr.ib()
-    _upload_dircap = attr.ib()
+    _write_participant = attr.ib(validator=attr.validators.provides(IWriteableParticipant))
     _status = attr.ib(validator=attr.validators.instance_of(FolderStatus))
 
     def initialize_upload_status(self):
@@ -365,11 +366,9 @@ class RemoteSnapshotCreator(object):
         # detect the conflict but any diff migh be weird.
 
         # update the entry in the DMD
-        yield self._tahoe_client.add_entry_to_mutable_directory(
-            self._upload_dircap.encode("utf-8"),
+        yield self._write_participant.update_snapshot(
             name,
-            remote_snapshot.capability.encode('utf-8'),
-            replace=True,
+            remote_snapshot.capability,
         )
 
         # if removing the stashed content fails here, we MUST move on

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -58,9 +58,6 @@ from .status import (
     StatusFactory,
     IStatus,
 )
-from .magicpath import (
-    magic2path,
-)
 from .snapshot import (
     create_author,
 )
@@ -458,7 +455,7 @@ class APIv1(object):
 
         return json.dumps([
             {
-                "relpath": magic2path(name),
+                "relpath": name,
                 "mtime": ns_to_seconds(ps.mtime_ns),
                 "last-updated": ns_to_seconds(last_updated_ns),
                 "last-upload-duration": float(upload_duration_ns) / 1000000000.0 if upload_duration_ns else None,
@@ -513,8 +510,7 @@ def _list_all_folder_snapshots(folder_config):
         representing all snapshots for that file.
     """
     for snapshot_path in folder_config.get_all_localsnapshot_paths():
-        relative_path = magic2path(snapshot_path)
-        yield relative_path, _list_all_path_snapshots(folder_config, snapshot_path)
+        yield snapshot_path, _list_all_path_snapshots(folder_config, snapshot_path)
 
 
 def _list_all_path_snapshots(folder_config, snapshot_path):


### PR DESCRIPTION
Fixes #499.

Doing this now was actually motivated by wanting to move `tahoe_client.add_entry_to_mutable_directory` for #420, but once I had that, it turned out that #499 was very easy to implement on top of that.