### PR TITLE
Don't pass snapshot to IMagicFileSystem.

### DIFF
--- a/docs/downloader.rst
+++ b/docs/downloader.rst
@@ -28,7 +28,7 @@ It is represented by an immutable directory and contains:
   Deletion Snapshots contain no such key.
 - ``metadata``: information about the Snapshot, a read-only Capability pointing to a JSON-serialized dict containing:
   - ``snapshot_version``: int(1) currently
-  - ``name``: the name of this snapshot (a mangled relative path)
+  - ``name``: the name of this snapshot (a relative path)
   - ``author``: a dict containing:
     - ``name``: arbitrary name
     - ``verify_key``: base64-encoded public key of the author

--- a/src/magic_folder/api_cli.py
+++ b/src/magic_folder/api_cli.py
@@ -100,8 +100,8 @@ def dump_state(options):
     print("  magic_path: {}".format(config.magic_path.path), file=options.stdout)
     print("  collective: {}".format(config.collective_dircap), file=options.stdout)
     print("  local snapshots:", file=options.stdout)
-    for snap_name in config.get_all_localsnapshot_paths():
-        snap = config.get_local_snapshot(snap_name)
+    for relpath in config.get_all_localsnapshot_paths():
+        snap = config.get_local_snapshot(relpath)
         parents = ""
         q = deque()
         q.append(snap)
@@ -109,15 +109,15 @@ def dump_state(options):
             s = q.popleft()
             parents += "{} -> ".format(s.identifier)
             q.extend(s.parents_local)
-        print("    {}: {}".format(snap_name, parents[:-4]), file=options.stdout)
+        print("    {}: {}".format(relpath, parents[:-4]), file=options.stdout)
     print("  remote snapshots:", file=options.stdout)
-    for snap_name, ps, last_update, upload_duration in config.get_all_current_snapshot_pathstates():
+    for relpath, ps, last_update, upload_duration in config.get_all_current_snapshot_pathstates():
         try:
-            cap = config.get_remotesnapshot(snap_name)
+            cap = config.get_remotesnapshot(relpath)
         except KeyError:
             cap = None
             continue
-        print("    {}:".format(snap_name), file=options.stdout)
+        print("    {}:".format(relpath), file=options.stdout)
         print("        cap: {}".format(cap), file=options.stdout)
         print("        mtime: {}".format(ps.mtime_ns), file=options.stdout)
         print("        size: {}".format(ps.size), file=options.stdout)

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -291,7 +291,7 @@ class RemoteSnapshotWithoutPathState(Exception):
     """
 
     folder_name = attr.ib(validator=attr.validators.instance_of(unicode))
-    snapshot_name = attr.ib(validator=attr.validators.instance_of(unicode))
+    relpath = attr.ib(validator=attr.validators.instance_of(unicode))
 
 
 def create_global_configuration(basedir, api_endpoint_str, tahoe_node_directory,
@@ -497,11 +497,11 @@ class SQLite3DatabaseLocation(object):
         return sqlite3.connect(self.location, *a, **kw)
 
 
-def _get_snapshots(cursor, name):
+def _get_snapshots(cursor, relpath):
     """
-    Load all of the snapshots associated with the given name.
+    Load all of the snapshots associated with the given relpath.
 
-    :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+    :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
 
     :return dict[unicode, unicode]: A mapping from unicode snapshot
         identifiers to unicode snapshot content path strings.
@@ -515,20 +515,20 @@ def _get_snapshots(cursor, name):
         WHERE
             [name] = ?
         """,
-        (name,),
+        (relpath,),
     )
     snapshots = cursor.fetchall()
     if len(snapshots) == 0:
-        raise KeyError(name)
+        raise KeyError(relpath)
     return dict(snapshots)
 
 
-def _get_metadata(cursor, name):
+def _get_metadata(cursor, relpath):
     """
     Load all of the metadata for all of the snapshots associated with the
-    given name.
+    given relpath.
 
-    :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+    :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
 
     :return dict[unicode, dict[unicode, unicode]]: A mapping from unicode
         snapshot identifiers to dicts of key/value metadata associated with
@@ -545,7 +545,7 @@ def _get_metadata(cursor, name):
         AND
             [local_snapshots].[name] = ?
         """,
-        (name,),
+        (relpath,),
     )
     metadata_rows = cursor.fetchall()
     metadata = {}
@@ -554,12 +554,12 @@ def _get_metadata(cursor, name):
     return metadata
 
 
-def _get_parents(cursor, name):
+def _get_parents(cursor, relpath):
     """
     Load all of the parent points for all of the snapshots associated with the
-    given name.
+    given relpath.
 
-    :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+    :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
 
     :return dict[unicode, [(int, bool, unicode)]]: A mapping from unicode
         snapshot identifiers to lists of associated parent pointer
@@ -582,7 +582,7 @@ def _get_parents(cursor, name):
         AND
             [local_snapshots].[name] = ?
         """,
-        (name,),
+        (relpath,),
     )
     parent_rows = cursor.fetchall()
     parents = {}
@@ -678,13 +678,13 @@ def _get_local_parents(identifier, parents, construct_parent_snapshot):
     )
 
 
-def _construct_local_snapshot(identifier, name, author, content_paths, metadata, parents):
+def _construct_local_snapshot(identifier, relpath, author, content_paths, metadata, parents):
     """
     Instantiate a ``LocalSnapshot`` corresponding to the given identifier.
 
     :param unicode identifier: The identifier of the snapshot to instantiate.
 
-    :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+    :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
 
     :param LocalAuthor author: The author associated with the snapshot.
 
@@ -701,7 +701,7 @@ def _construct_local_snapshot(identifier, name, author, content_paths, metadata,
     """
     return LocalSnapshot(
         identifier=UUID(hex=identifier),
-        name=name,
+        relpath=relpath,
         author=author,
         content_path=FilePath(content_paths[identifier]),
         metadata=metadata.get(identifier, {}),
@@ -711,7 +711,7 @@ def _construct_local_snapshot(identifier, name, author, content_paths, metadata,
             parents,
             partial(
                 _construct_local_snapshot,
-                name=name,
+                relpath=relpath,
                 author=author,
                 content_paths=content_paths,
                 metadata=metadata,
@@ -834,29 +834,29 @@ class MagicFolderConfig(object):
         return FilePath(path_raw)
 
     @with_cursor
-    def get_local_snapshot(self, cursor, name):
+    def get_local_snapshot(self, cursor, relpath):
         """
         return an instance of LocalSnapshot corresponding to
-        the given name and author. Traversing the parents
+        the given relpath and author. Traversing the parents
         would give the entire history of local snapshots.
 
-        :param unicode name: The name of the snapshot to find.  See
-            ``LocalSnapshot.name``.
+        :param unicode relpath: The relpath of the snapshot to find.  See
+            ``LocalSnapshot.relpath``.
 
         :raise KeyError: If there is no matching snapshot for the given path.
 
         :returns: An instance of LocalSnapshot for the given path.
         """
-        # Read all the state for this name from the database.
-        snapshots = _get_snapshots(cursor, name)
-        metadata = _get_metadata(cursor, name)
-        parents = _get_parents(cursor, name)
+        # Read all the state for this relpath from the database.
+        snapshots = _get_snapshots(cursor, relpath)
+        metadata = _get_metadata(cursor, relpath)
+        parents = _get_parents(cursor, relpath)
 
         # Turn it into the desired in-memory representation.
         leaf_identifier = _find_leaf_snapshot(set(snapshots), parents)
         return _construct_local_snapshot(
             leaf_identifier,
-            name,
+            relpath,
             self._get_author.__wrapped__(self, cursor),
             snapshots,
             metadata,
@@ -894,7 +894,7 @@ class MagicFolderConfig(object):
                 VALUES
                     (?, ?, ?)
                 """,
-                (unicode(snapshot.identifier), snapshot.name, snapshot.content_path.asTextMode("utf-8").path),
+                (unicode(snapshot.identifier), snapshot.relpath, snapshot.content_path.asTextMode("utf-8").path),
             )
         except sqlite3.IntegrityError:
             # The UNIQUE constraint on `identifier` failed - which *should*
@@ -963,41 +963,41 @@ class MagicFolderConfig(object):
         return set(r[0] for r in rows)
 
     @with_cursor
-    def delete_localsnapshot(self, cursor, name):
+    def delete_localsnapshot(self, cursor, relpath):
         """
-        remove the row corresponding to the given name from the local_snapshots table
+        remove the row corresponding to the given relpath from the local_snapshots table
 
-        :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+        :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
         """
         action = DELETE_SNAPSHOTS(
-            relpath=name,
+            relpath=relpath,
         )
         with action:
             cursor.execute("DELETE FROM [local_snapshots]"
                            " WHERE [name]=?",
-                           (name,))
+                           (relpath,))
 
 
     @with_cursor
-    def store_uploaded_snapshot(self, cursor, name, remote_snapshot, upload_started_at):
+    def store_uploaded_snapshot(self, cursor, relpath, remote_snapshot, upload_started_at):
         """
         Store the remote snapshot cap of a snapshot that we uploaded.
 
         This assumes that the path state was already recoreded when we stored
         the corresponding local snapshot.
 
-        :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+        :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
         :param RemoteSnapshot remote_snapshot: The snapshot to store.
         :param float upload_started_at: Timestamp when this upload started, in seconds.
 
         :raises RemoteSnapshotWithoutPathState:
             if there is not already path state in the database for the given
-            name.
+            relpath.
         """
         # TODO: We should consider merging this with delete_localsnapshot
         snapshot_cap = remote_snapshot.capability
         action = STORE_OR_UPDATE_SNAPSHOTS(
-            relpath=name,
+            relpath=relpath,
         )
         now_ns = seconds_to_ns(self._get_current_timestamp())
         duration_ns = now_ns - seconds_to_ns(upload_started_at)
@@ -1011,27 +1011,27 @@ class MagicFolderConfig(object):
                 WHERE
                     [name]=?
                 """,
-                (snapshot_cap, now_ns, duration_ns, name),
+                (snapshot_cap, now_ns, duration_ns, relpath),
             )
             if cursor.rowcount != 1:
                 raise RemoteSnapshotWithoutPathState(
-                    folder_name=self.name, snapshot_name=name
+                    folder_name=self.name, relpath=relpath
                 )
             action.add_success_fields(insert_or_update="update")
 
     @with_cursor
-    def store_downloaded_snapshot(self, cursor, name, remote_snapshot, path_state):
+    def store_downloaded_snapshot(self, cursor, relpath, remote_snapshot, path_state):
         """
         Store the remote snapshot cap for a file that we downloaded, and
         the corresponding path state of the written file.
 
-        :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+        :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
         :param PathState path_state: The state of the path to record.
         :param RemoteSnapshot remote_snapshot: The snapshot to store.
         """
         snapshot_cap = remote_snapshot.capability
         action = STORE_OR_UPDATE_SNAPSHOTS(
-            relpath=name,
+            relpath=relpath,
         )
         now_ns = seconds_to_ns(self._get_current_timestamp())
         with action:
@@ -1039,7 +1039,7 @@ class MagicFolderConfig(object):
                 cursor.execute(
                     "INSERT INTO current_snapshots (name, snapshot_cap, mtime_ns, ctime_ns, size, last_updated_ns, upload_duration_ns)"
                     " VALUES (?,?,?,?,?,?,?)",
-                    (name, snapshot_cap, path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns, None),
+                    (relpath, snapshot_cap, path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns, None),
                 )
                 action.add_success_fields(insert_or_update="insert")
             except (sqlite3.IntegrityError, sqlite3.OperationalError):
@@ -1047,20 +1047,20 @@ class MagicFolderConfig(object):
                     "UPDATE current_snapshots"
                     " SET snapshot_cap=?, mtime_ns=?, ctime_ns=?, size=?, last_updated_ns=?, upload_duration_ns=?"
                     " WHERE [name]=?",
-                    (snapshot_cap, path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns, None, name),
+                    (snapshot_cap, path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns, None, relpath),
                 )
                 action.add_success_fields(insert_or_update="update")
 
     @with_cursor
-    def store_currentsnapshot_state(self, cursor, name, path_state):
+    def store_currentsnapshot_state(self, cursor, relpath, path_state):
         """
-        Store or update the path state of the given name.
+        Store or update the path state of the given relpath.
 
-        :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+        :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
         :param PathState path_state: The path state to store.
         """
         action = STORE_OR_UPDATE_SNAPSHOTS(
-            relpath=name,
+            relpath=relpath,
         )
         now_ns = seconds_to_ns(self._get_current_timestamp())
         with action:
@@ -1068,7 +1068,7 @@ class MagicFolderConfig(object):
                 cursor.execute(
                     "INSERT INTO current_snapshots (name, mtime_ns, ctime_ns, size, last_updated_ns)"
                     " VALUES (?,?,?,?,?)",
-                    (name, path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns),
+                    (relpath, path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns),
                 )
                 action.add_success_fields(insert_or_update="insert")
             except (sqlite3.IntegrityError, sqlite3.OperationalError):
@@ -1076,7 +1076,7 @@ class MagicFolderConfig(object):
                     "UPDATE current_snapshots"
                     " SET mtime_ns=?, ctime_ns=?, size=?, last_updated_ns=?"
                     " WHERE [name]=?",
-                    (path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns, name),
+                    (path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns, relpath),
                 )
                 action.add_success_fields(insert_or_update="update")
 
@@ -1114,54 +1114,54 @@ class MagicFolderConfig(object):
         return [(r[0], ns_to_seconds(r[1]), ns_to_seconds(r[2])) for r in rows]
 
     @with_cursor
-    def get_remotesnapshot(self, cursor, name):
+    def get_remotesnapshot(self, cursor, relpath):
         """
         return the cap that represents the latest remote snapshot that
         the client has recorded in the db.
 
-        :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+        :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
 
-        :raise KeyError: If no snapshot exists for the given name.
+        :raise KeyError: If no snapshot exists for the given relpath.
 
         :returns: A byte string that represents the RemoteSnapshot cap.
         """
         action = FETCH_CURRENT_SNAPSHOTS_FROM_DB(
-            relpath=name,
+            relpath=relpath,
         )
         with action:
             cursor.execute("SELECT snapshot_cap FROM current_snapshots"
                            " WHERE [name]=?",
-                           (name,))
+                           (relpath,))
             row = cursor.fetchone()
             if row and row[0] is not None:
                 return row[0].encode("utf-8")
-            raise KeyError(name)
+            raise KeyError(relpath)
 
     @with_cursor
-    def get_currentsnapshot_pathstate(self, cursor, name):
+    def get_currentsnapshot_pathstate(self, cursor, relpath):
         """
         return the timestamp of the latest remote snapshot that the client
         has recorded in the db.
 
-        :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+        :param unicode relpath: The relpath to match.  See ``LocalSnapshot.relpath``.
 
-        :raise KeyError: If no snapshot exists for the given name.
+        :raise KeyError: If no snapshot exists for the given relpath.
 
         :returns int: the timestamp of the remotesnapshot
         """
         action = FETCH_CURRENT_SNAPSHOTS_FROM_DB(
-            relpath=name,
+            relpath=relpath,
         )
         with action:
             cursor.execute(
                 "SELECT mtime_ns, ctime_ns, size FROM current_snapshots"
                 " WHERE [name]=?",
-                (name,),
+                (relpath,),
             )
             row = cursor.fetchone()
             if row:
                 return PathState(mtime_ns=row[0], ctime_ns=row[1], size=row[2])
-            raise KeyError(name)
+            raise KeyError(relpath)
 
     @with_cursor
     def get_all_current_snapshot_pathstates(self, cursor):
@@ -1170,7 +1170,7 @@ class MagicFolderConfig(object):
         'current_snapshot' table.
 
         :returns Iterable[(unicode, PathState)]: an iterable of
-            3-tuples of (name, PathState instance, last-update), one for each file
+            3-tuples of (relpath, PathState instance, last-update), one for each file
             (ordered by last-updated timestamp)
         """
         cursor.execute(
@@ -1186,7 +1186,7 @@ class MagicFolderConfig(object):
 
         return [
             (
-                row[0],  # name
+                row[0],  # relpath
                 PathState(mtime_ns=row[1], ctime_ns=row[2], size=row[3]),
                 row[4],  # last_updated_ns
                 row[5],  # upload_duration_ns
@@ -1339,7 +1339,7 @@ class GlobalConfigDatabase(object):
     Low-level access to the global configuration database
 
     :attr WeakValueDictionary[unicode, MagicFolderConfig] _folder_config_cache:
-        This is a cache of `MagicFolderConfig` instances keyed by the folder name.
+        This is a cache of `MagicFolderConfig` instances keyed by the folder relpath.
         We do this so we have only a single :py:`sqlite3.Connection` to the
         underlying state db.
     """

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -221,7 +221,7 @@ _magicfolder_config_schema = Schema([
         -- This table represents the current state of the file on disk, as last known to us
         CREATE TABLE [current_snapshots]
         (
-            [name]             TEXT PRIMARY KEY, -- mangled name in UTF-8
+            [name]             TEXT PRIMARY KEY, -- relative file path in UTF-8
             [snapshot_cap]     TEXT,             -- Tahoe-LAFS URI that represents the most recent remote snapshot
                                                  -- associated with this file, either as downloaded from a peer
                                                  -- or uploaded from local changes

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -152,7 +152,7 @@ class RemoteSnapshotCacheService(service.Service):
         )
         self._cached_snapshots[snapshot_cap] = snapshot
         Message.log(message_type="remote-cache:cached",
-                    name=snapshot.name,
+                    name=snapshot.metadata['name'],
                     capability=snapshot.capability)
 
         # breadth-first traversal of the parents
@@ -301,7 +301,7 @@ class MagicFolderUpdater(object):
         conflict_path = relpath + ".conflict-{}".format(snapshot.author.name)
 
         with start_action(action_type="downloader:updater:process",
-                          name=snapshot.name,
+                          name=relpath,
                           capability=snapshot.capability,
                           ) as action:
             local_path = self._config.magic_path.preauthChild(relpath)
@@ -373,7 +373,7 @@ class MagicFolderUpdater(object):
             try:
                 with start_action(
                     action_type=u"downloader:updater:content-to-staging",
-                    name=snapshot.name,
+                    name=relpath,
                     capability=snapshot.capability,
                 ):
                     try:

--- a/src/magic_folder/participants.py
+++ b/src/magic_folder/participants.py
@@ -96,9 +96,9 @@ class IWriteableParticipant(Interface):
     """
 
     @inlineCallbacks
-    def update_snapshot(name, capability):
+    def update_snapshot(relpath, capability):
         """
-        Update the snapshot with the given name.
+        Update the snapshot with the given relpath.
         """
 
 
@@ -277,8 +277,8 @@ class _CollectiveDirnodeParticipant(object):
         """
         result = yield self._tahoe_client.list_directory(self.dircap)
         returnValue({
-            magic2path(encoded_relpath_u): SnapshotEntry(child, metadata)
-            for (encoded_relpath_u, (child, metadata))
+            magic2path(mangled_relpath): SnapshotEntry(child, metadata)
+            for (mangled_relpath, (child, metadata))
             in result.items()
         })
 
@@ -309,13 +309,13 @@ class _WriteableParticipant(object):
             ),
         )
 
-    def update_snapshot(self, name, capability):
+    def update_snapshot(self, relpath, capability):
         """
-        Update the snapshot with the given name.
+        Update the snapshot with the given relpath.
         """
         return self._tahoe_client.add_entry_to_mutable_directory(
             self.upload_cap.encode("ascii"),
-            path2magic(name),
+            path2magic(relpath),
             capability.encode("ascii"),
             replace=True,
         )

--- a/src/magic_folder/snapshot.py
+++ b/src/magic_folder/snapshot.py
@@ -207,7 +207,7 @@ def sign_snapshot(local_author, snapshot_name, content_capability, metadata_capa
 
     :param LocalAuthor local_author: the author to sign the data with
 
-    :param unicode snapshot_name: mangled snapshot name to sign
+    :param unicode snapshot_name: snapshot name to sign
 
     :param bytes content_capability: the Tahoe immutable
         capability-string of the actual snapshot data.
@@ -345,9 +345,6 @@ class RemoteSnapshot(object):
     Represents a snapshot corresponding to a particular version of a
     file authored by a particular human.
 
-    :ivar unicode name: the name of this Snapshot. This is a mangled
-        path relative to our local magic-folder path.
-
     :ivar dict metadata: a dict containing metadata about this
         Snapshot. Usually these are unicode keys mapping to data that
         can be anything JSON can serialize (so text, numbers, booleans
@@ -456,7 +453,7 @@ def create_snapshot(name, author, data_producer, snapshot_stash_dir, parents=Non
     data is stashed in `snapshot_stash_dir` before this function
     returns.
 
-    :param name: The name for this snapshot (usually the 'mangled' filename).
+    :param name: The name for this snapshot (usually the relative path of the file).
 
     :param author: LocalAuthor instance (which will have a valid
         signing-key)

--- a/src/magic_folder/snapshot.py
+++ b/src/magic_folder/snapshot.py
@@ -257,7 +257,7 @@ class LocalSnapshot(object):
     :ivar [bytes] parents_remote: The capability strings of snapshots that are
         known to exist remotely.
     """
-    name = attr.ib()
+    relpath = attr.ib()
     author = attr.ib()
     metadata = attr.ib()
     content_path = attr.ib(validator=attr.validators.instance_of(FilePath))
@@ -289,7 +289,7 @@ class LocalSnapshot(object):
 
         def _serialized_dict(local_snapshot):
             serialized = {
-                'name': local_snapshot.name,
+                'relpath': local_snapshot.relpath,
                 'metadata': local_snapshot.metadata,
                 'identifier': unicode(local_snapshot.identifier),
                 'content_path': local_snapshot.content_path.path,
@@ -321,10 +321,10 @@ class LocalSnapshot(object):
         local_snapshot_dict = json.loads(serialized)
 
         def deserialize_dict(snapshot_dict, author):
-            name = snapshot_dict["name"]
+            relpath = snapshot_dict["relpath"]
 
             return cls(
-                name=name,
+                relpath=relpath,
                 author=author,
                 identifier=UUID(hex=snapshot_dict["identifier"]),
                 metadata=snapshot_dict["metadata"],
@@ -446,14 +446,14 @@ def create_snapshot_from_capability(snapshot_cap, tahoe_client):
 
 
 @inline_callbacks
-def create_snapshot(name, author, data_producer, snapshot_stash_dir, parents=None,
+def create_snapshot(relpath, author, data_producer, snapshot_stash_dir, parents=None,
                     raw_remote_parents=None, modified_time=None):
     """
     Creates a new LocalSnapshot instance that is in-memory only. All
     data is stashed in `snapshot_stash_dir` before this function
     returns.
 
-    :param name: The name for this snapshot (usually the relative path of the file).
+    :param relpath: The relative path of the file.
 
     :param author: LocalAuthor instance (which will have a valid
         signing-key)
@@ -529,7 +529,7 @@ def create_snapshot(name, author, data_producer, snapshot_stash_dir, parents=Non
 
     returnValue(
         LocalSnapshot(
-            name=name,
+            relpath=relpath,
             author=author,
             metadata={
                 "mtime": modified_time,
@@ -616,7 +616,7 @@ def write_snapshot_to_tahoe(snapshot, author_key, tahoe_client):
     # create our metadata
     snapshot_metadata = {
         "snapshot_version": SNAPSHOT_VERSION,
-        "name": snapshot.name,
+        "name": snapshot.relpath,
         "author": snapshot.author.to_remote_author().to_json(),
         "modification_time": snapshot.metadata["mtime"],
         "parents": [
@@ -630,7 +630,7 @@ def write_snapshot_to_tahoe(snapshot, author_key, tahoe_client):
 
     # sign the snapshot (which can only happen after we have the
     # content-capability and metadata-capability)
-    author_signature = sign_snapshot(author_key, snapshot.name, content_cap, metadata_cap)
+    author_signature = sign_snapshot(author_key, snapshot.relpath, content_cap, metadata_cap)
     author_signature_base64 = base64.b64encode(author_signature.signature)
 
     # create the actual snapshot: an immutable directory with

--- a/src/magic_folder/snapshot.py
+++ b/src/magic_folder/snapshot.py
@@ -365,7 +365,6 @@ class RemoteSnapshot(object):
         retrieve the contents.
     """
 
-    name = attr.ib()
     author = attr.ib()  # any SnapshotAuthor instance
     metadata = attr.ib()
     capability = attr.ib()
@@ -440,7 +439,6 @@ def create_snapshot_from_capability(snapshot_cap, tahoe_client):
 
     returnValue(
         RemoteSnapshot(
-            name=name,
             author=author,
             metadata=metadata,
             content_cap=content_cap,
@@ -660,7 +658,6 @@ def write_snapshot_to_tahoe(snapshot, author_key, tahoe_client):
     # snapshot, so we shouldn't yet delete the LocalSnapshot
     returnValue(
         RemoteSnapshot(
-            name=snapshot.name,
             author=snapshot.author.to_remote_author(),
             metadata=snapshot_metadata,
             parents_raw=parents_raw,

--- a/src/magic_folder/test/cli/test_api_cli.py
+++ b/src/magic_folder/test/cli/test_api_cli.py
@@ -66,8 +66,8 @@ class ScanMagicFolder(AsyncTestCase):
         """
         Scanning a magic folder creates a snapshot of new files.
         """
-        name = "file"
-        local = self.magic_path.child(name)
+        relpath = "file"
+        local = self.magic_path.child(relpath)
         local.setContent(b"content")
 
         outcome = yield self.api_cli(
@@ -85,7 +85,7 @@ class ScanMagicFolder(AsyncTestCase):
         snapshot_paths = self.folder_config.get_all_localsnapshot_paths()
         self.assertThat(
             snapshot_paths,
-            Equals({name}),
+            Equals({relpath}),
         )
 
     @inline_callbacks
@@ -94,8 +94,8 @@ class ScanMagicFolder(AsyncTestCase):
         If a folder is not passed to ``magic-folder-api scan-folder``,
         an error is returned.
         """
-        name = "file"
-        local = self.magic_path.child(name)
+        relpath = "file"
+        local = self.magic_path.child(relpath)
         local.setContent(b"content")
 
         outcome = yield self.api_cli(

--- a/src/magic_folder/test/matchers.py
+++ b/src/magic_folder/test/matchers.py
@@ -54,7 +54,7 @@ class MatchesAuthorSignature(object):
             u"{name}\n"
         ).format(
             content_capability=self.remote_snapshot.content_cap,
-            name=self.remote_snapshot.name,
+            name=self.remote_snapshot.metadata['name'],
         ).encode("utf8")
 
         try:

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -405,9 +405,9 @@ def remote_snapshots(names=path_segments(), authors=remote_authors()):
     """
     return builds(
         RemoteSnapshot,
-        name=names,
         author=authors,
         metadata=fixed_dictionaries({
+            "name": names,
             "modification_time": integers(min_value=0, max_value=2**32),
         }),
         capability=tahoe_lafs_immutable_dir_capabilities(),

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -399,7 +399,7 @@ def unique_value_dictionaries(keys, values, min_size=None, max_size=None):
     )
 
 
-def remote_snapshots(names=path_segments(), authors=remote_authors()):
+def remote_snapshots(relpaths=path_segments(), authors=remote_authors()):
     """
     Build ``RemoteSnapshot`` instances.
     """
@@ -407,7 +407,7 @@ def remote_snapshots(names=path_segments(), authors=remote_authors()):
         RemoteSnapshot,
         author=authors,
         metadata=fixed_dictionaries({
-            "name": names,
+            "name": relpaths,
             "modification_time": integers(min_value=0, max_value=2**32),
         }),
         capability=tahoe_lafs_immutable_dir_capabilities(),
@@ -434,7 +434,7 @@ def local_snapshots():
     """
     return builds(
         LocalSnapshot,
-        name=relative_paths(),
+        relpath=relative_paths(),
         author=local_authors(),
         metadata=dictionaries(text(), text()),
         content_path=absolute_paths().map(FilePath),

--- a/src/magic_folder/test/test_api_cli.py
+++ b/src/magic_folder/test/test_api_cli.py
@@ -569,7 +569,6 @@ class TestDumpState(AsyncTestCase):
         config.store_downloaded_snapshot(
             "bar",
             RemoteSnapshot(
-                "bar",
                 author,
                 {"modification_time": 0},
                 capability="URI:DIR2-CHK:l7b3rn6pha6c2ipbbo4yxvunvy:c6ppejrkip4cdfo3kmyju36qbb6bbptzhh3pno7jb5b5myzoxkja:1:5:329",

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -759,8 +759,8 @@ class ConflictTests(AsyncTestCase):
         self.assertThat(
             self.filesystem.actions,
             Equals([
-                ("download", "foo", remote0),
-                ("conflict", "foo", remote0),
+                ("download", "foo", remote0.content_cap),
+                ("conflict", "foo", "foo.conflict-{}".format(self.carol.name), remote0.content_cap),
             ])
         )
 
@@ -809,8 +809,8 @@ class ConflictTests(AsyncTestCase):
         self.assertThat(
             self.filesystem.actions,
             Equals([
-                ("download", "foo", remote0),
-                ("overwrite", "foo", remote0),
+                ("download", "foo", remote0.content_cap),
+                ("overwrite", "foo", remote0.content_cap),
             ])
         )
 
@@ -852,8 +852,8 @@ class ConflictTests(AsyncTestCase):
         self.assertThat(
             self.filesystem.actions,
             Equals([
-                ("download", "foo", youngest),
-                ("overwrite", "foo", youngest),
+                ("download", "foo", youngest.content_cap),
+                ("overwrite", "foo", youngest.content_cap),
             ])
         )
 
@@ -909,8 +909,8 @@ class ConflictTests(AsyncTestCase):
         self.assertThat(
             self.filesystem.actions,
             Equals([
-                ("download", "foo", child),
-                ("conflict", "foo", child),
+                ("download", "foo", child.content_cap),
+                ("conflict", "foo", "foo.conflict-{}".format(self.alice.name), child.content_cap),
             ])
         )
 
@@ -975,7 +975,7 @@ class ConflictTests(AsyncTestCase):
         )
         self.remote_cache._cached_snapshots[parent_cap] = parent
 
-        def permissions_suck(relpath, remote_snap, staged_content):
+        def permissions_suck(relpath, mtime, staged_content):
             """
             cause the filesystem to fail to write due to a permissions problem
             """
@@ -1061,7 +1061,7 @@ class ConflictTests(AsyncTestCase):
         )
         self.remote_cache._cached_snapshots[parent_cap] = parent
 
-        def network_is_out(relpath, remote_snap, tahoe_client):
+        def network_is_out(relpath, file_cap, tahoe_client):
             """
             download fails for some reason
             """

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -157,10 +157,10 @@ class CacheTests(SyncTestCase):
         Caching a single RemoteSnapshot with no parents works
         """
         self.setup_example()
-        name = "foo"
+        relpath = "foo"
         metadata = {
             "snapshot_version": 1,
-            "name": name,
+            "name": relpath,
             "author": self.author.to_remote_author().to_json(),
             "parents": [],
         }
@@ -193,7 +193,7 @@ class CacheTests(SyncTestCase):
                                     "author_signature": base64.b64encode(
                                         sign_snapshot(
                                             self.author,
-                                            name,
+                                            relpath,
                                             content_cap,
                                             metadata_cap
                                         ).signature
@@ -217,7 +217,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": Equals([]),
-                        "name": Equals("foo"),
+                        "name": Equals(relpath),
                     }),
                 )
             )
@@ -228,14 +228,14 @@ class CacheTests(SyncTestCase):
         Caching a RemoteSnapshot with parents works
         """
         self.setup_example()
-        name = "foo"
+        relpath = "foo"
         parents = []
         genesis = None
 
         for who in range(5):
             metadata = {
                 "snapshot_version": 1,
-                "name": name,
+                "name": relpath,
                 "author": self.author.to_remote_author().to_json(),
                 "parents": parents,
             }
@@ -271,7 +271,7 @@ class CacheTests(SyncTestCase):
                                             "author_signature": base64.b64encode(
                                                 sign_snapshot(
                                                     self.author,
-                                                    name,
+                                                    relpath,
                                                     content_cap,
                                                     metadata_cap
                                                 ).signature
@@ -297,7 +297,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": Equals([]),
-                        "name": Equals("foo"),
+                        "name": Equals(relpath),
                     }),
                 )
             )
@@ -317,7 +317,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": AfterPreprocessing(len, Equals(1)),
-                        "name": Equals("foo"),
+                        "name": Equals(relpath),
                     }),
                 )
             )
@@ -339,7 +339,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": AfterPreprocessing(len, Equals(1)),
-                        "name": Equals("foo"),
+                        "name": Equals(relpath),
                     }),
                 )
             )
@@ -734,7 +734,7 @@ class ConflictTests(AsyncTestCase):
 
         local0_content = b"dummy content"
         local0 = yield create_snapshot(
-            name="foo",
+            relpath="foo",
             author=self.alice,
             data_producer=io.BytesIO(local0_content),
             snapshot_stash_dir=self.state_path,
@@ -748,7 +748,7 @@ class ConflictTests(AsyncTestCase):
         # tell the updater to examine the remote-snapshot
         yield self.updater.add_remote_snapshot("foo", remote0)
 
-        # we have a local-snapshot for the same name as the incoming
+        # we have a local-snapshot for the same relpath as the incoming
         # remote, so this is a conflict
 
         self.assertThat(
@@ -796,7 +796,7 @@ class ConflictTests(AsyncTestCase):
         # tell the updater to examine the remote-snapshot
         yield self.updater.add_remote_snapshot("foo", remote0)
 
-        # we have a local-snapshot for the same name as the incoming
+        # we have a local-snapshot for the same relpath as the incoming
         # remote, so this is a conflict
 
         self.assertThat(

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -214,7 +214,6 @@ class CacheTests(SyncTestCase):
             self.cache.get_snapshot_from_capability(cap),
             succeeded(
                 MatchesStructure(
-                    name=Equals("foo"),
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": Equals([]),
@@ -295,7 +294,6 @@ class CacheTests(SyncTestCase):
             self.cache.get_snapshot_from_capability(genesis),
             succeeded(
                 MatchesStructure(
-                    name=Equals("foo"),
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": Equals([]),
@@ -316,7 +314,6 @@ class CacheTests(SyncTestCase):
             self.cache.get_snapshot_from_capability(cap),
             succeeded(
                 MatchesStructure(
-                    name=Equals("foo"),
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": AfterPreprocessing(len, Equals(1)),
@@ -339,7 +336,6 @@ class CacheTests(SyncTestCase):
             self.cache.get_snapshot_from_capability(cap),
             succeeded(
                 MatchesStructure(
-                    name=Equals("foo"),
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": AfterPreprocessing(len, Equals(1)),
@@ -728,7 +724,6 @@ class ConflictTests(AsyncTestCase):
 
         cap0 = b"URI:DIR2-CHK:aaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1:5:376"
         remote0 = RemoteSnapshot(
-            name="foo",
             author=self.carol,
             metadata={"modification_time": 0},
             capability=cap0,
@@ -773,7 +768,6 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:bbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:1:5:376"
         parent = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,
@@ -788,7 +782,6 @@ class ConflictTests(AsyncTestCase):
 
         cap0 = b"URI:DIR2-CHK:aaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1:5:376"
         remote0 = RemoteSnapshot(
-            name="foo",
             author=self.carol,
             metadata={"modification_time": 0},
             capability=cap0,
@@ -826,7 +819,6 @@ class ConflictTests(AsyncTestCase):
         for letter in 'abcd':
             parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format(letter * 26, letter * 52)
             parent = RemoteSnapshot(
-                name="foo",
                 author=self.alice,
                 metadata={"modification_time": 0},
                 capability=parent_cap,
@@ -865,7 +857,6 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,
@@ -876,7 +867,6 @@ class ConflictTests(AsyncTestCase):
 
         child_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('b' * 26, 'b' * 52)
         child = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=child_cap,
@@ -887,7 +877,6 @@ class ConflictTests(AsyncTestCase):
 
         other_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('z' * 26, 'z' * 52)
         other = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=other_cap,
@@ -922,7 +911,6 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,
@@ -933,7 +921,6 @@ class ConflictTests(AsyncTestCase):
 
         child_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('b' * 26, 'b' * 52)
         child = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=child_cap,
@@ -966,7 +953,6 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,
@@ -1052,7 +1038,6 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
-            name="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -157,10 +157,10 @@ class CacheTests(SyncTestCase):
         Caching a single RemoteSnapshot with no parents works
         """
         self.setup_example()
-        mangled_name = "foo"
+        name = "foo"
         metadata = {
             "snapshot_version": 1,
-            "name": mangled_name,
+            "name": name,
             "author": self.author.to_remote_author().to_json(),
             "parents": [],
         }
@@ -193,7 +193,7 @@ class CacheTests(SyncTestCase):
                                     "author_signature": base64.b64encode(
                                         sign_snapshot(
                                             self.author,
-                                            mangled_name,
+                                            name,
                                             content_cap,
                                             metadata_cap
                                         ).signature
@@ -228,14 +228,14 @@ class CacheTests(SyncTestCase):
         Caching a RemoteSnapshot with parents works
         """
         self.setup_example()
-        mangled_name = "foo"
+        name = "foo"
         parents = []
         genesis = None
 
         for who in range(5):
             metadata = {
                 "snapshot_version": 1,
-                "name": mangled_name,
+                "name": name,
                 "author": self.author.to_remote_author().to_json(),
                 "parents": parents,
             }
@@ -271,7 +271,7 @@ class CacheTests(SyncTestCase):
                                             "author_signature": base64.b64encode(
                                                 sign_snapshot(
                                                     self.author,
-                                                    mangled_name,
+                                                    name,
                                                     content_cap,
                                                     metadata_cap
                                                 ).signature

--- a/src/magic_folder/test/test_participants.py
+++ b/src/magic_folder/test/test_participants.py
@@ -517,8 +517,8 @@ class CollectiveParticipantTests(SyncTestCase):
         root._uri.data[upload_dircap] = dumps([
             u"dirnode",
             {u"children": {
-                path2magic(name): format_filenode(cap, {u"version": version})
-                for (name, (cap, version))
+                path2magic(relpath): format_filenode(cap, {u"version": version})
+                for (relpath, (cap, version))
                 in children.items()
             }},
         ])

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -126,7 +126,6 @@ class FindUpdatesTests(SyncTestCase):
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
         snap = RemoteSnapshot(
-            "new-file",
             self.author,
             metadata={
                 "modification_time": int(
@@ -161,7 +160,6 @@ class FindUpdatesTests(SyncTestCase):
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
         snap = RemoteSnapshot(
-            name,
             self.author,
             metadata={
                 # this remote is 2min older than our local file

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -69,11 +69,11 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_new(self, name):
+    def test_scan_new(self, relpath):
         """
         A completely new file is scanned
         """
-        local = self.magic_path.preauthChild(name)
+        local = self.magic_path.preauthChild(relpath)
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
 
@@ -95,11 +95,11 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_symlink(self, name):
+    def test_scan_symlink(self, relpath):
         """
         A completely new symlink is ignored
         """
-        local = self.magic_path.preauthChild(name)
+        local = self.magic_path.preauthChild(relpath)
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").linkTo(local.asBytesMode("utf-8"))
 
@@ -118,11 +118,11 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_nothing(self, name):
+    def test_scan_nothing(self, relpath):
         """
         An existing, non-updated file is not scanned
         """
-        local = self.magic_path.preauthChild(name)
+        local = self.magic_path.preauthChild(relpath)
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
         snap = RemoteSnapshot(
@@ -137,7 +137,7 @@ class FindUpdatesTests(SyncTestCase):
             content_cap="URI:CHK:",
         )
         self.config.store_downloaded_snapshot(
-            name, snap, get_pathinfo(local).state
+            relpath, snap, get_pathinfo(local).state
         )
 
         files = []
@@ -152,11 +152,11 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_something_remote(self, name):
+    def test_scan_something_remote(self, relpath):
         """
         We scan an update to a file we already know about.
         """
-        local = self.magic_path.preauthChild(name)
+        local = self.magic_path.preauthChild(relpath)
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
         snap = RemoteSnapshot(
@@ -173,7 +173,7 @@ class FindUpdatesTests(SyncTestCase):
             content_cap="URI:CHK:",
         )
         self.config.store_downloaded_snapshot(
-            name,
+            relpath,
             snap,
             OLD_PATH_STATE,
         )
@@ -190,7 +190,7 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_something_local(self, name):
+    def test_scan_something_local(self, relpath):
         """
         We scan an update to a file we already know about (but only locally).
         """
@@ -213,7 +213,7 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_existing_to_directory(self, name):
+    def test_scan_existing_to_directory(self, relpath):
         """
         When we scan a path that we have a snapshot for, but it is now a directory,
         we ignore it, and report an error.
@@ -247,12 +247,12 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_once(self, name):
+    def test_scan_once(self, relpath):
         """
         The scanner service discovers a_file when a scan is requested.
         """
-        name = "a_file"
-        local = self.magic_path.preauthChild(name)
+        relpath = "a_file"
+        local = self.magic_path.preauthChild(relpath)
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
 
@@ -283,13 +283,13 @@ class FindUpdatesTests(SyncTestCase):
     @given(
         relative_paths(),
     )
-    def test_scan_periodic(self, name):
+    def test_scan_periodic(self, relpath):
         """
         The scanner service iteself discovers a_file, when a scan interval is
         set.
         """
-        name = "a_file"
-        local = self.magic_path.preauthChild(name)
+        relpath = "a_file"
+        local = self.magic_path.preauthChild(relpath)
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
 

--- a/src/magic_folder/test/test_snapshot.py
+++ b/src/magic_folder/test/test_snapshot.py
@@ -155,7 +155,7 @@ class TestLocalSnapshot(SyncTestCase):
         data = io.BytesIO(content)
 
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data,
             snapshot_stash_dir=self.stash_dir,
@@ -183,7 +183,7 @@ class TestLocalSnapshot(SyncTestCase):
         data = io.BytesIO(content)
 
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data,
             snapshot_stash_dir=self.stash_dir,
@@ -214,7 +214,7 @@ class TestLocalSnapshot(SyncTestCase):
         parents = []
 
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data1,
             snapshot_stash_dir=self.stash_dir,
@@ -227,7 +227,7 @@ class TestLocalSnapshot(SyncTestCase):
 
         data2 = io.BytesIO(content2)
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data2,
             snapshot_stash_dir=self.stash_dir,
@@ -256,7 +256,7 @@ class TestLocalSnapshot(SyncTestCase):
 
         # create a local snapshot and commit it to the grid
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data1,
             snapshot_stash_dir=self.stash_dir,
@@ -271,7 +271,7 @@ class TestLocalSnapshot(SyncTestCase):
         # now modify the same file and create a new local snapshot
         data2 = io.BytesIO(content2)
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data2,
             snapshot_stash_dir=self.stash_dir,
@@ -316,7 +316,7 @@ class TestRemoteSnapshot(SyncTestCase):
         # create LocalSnapshot
         local_snapshot = success_result_of(
             create_snapshot(
-                name=filename,
+                relpath=filename,
                 author=self.alice,
                 data_producer=data,
                 snapshot_stash_dir=self.stash_dir,
@@ -368,7 +368,7 @@ class TestRemoteSnapshot(SyncTestCase):
 
         local_snapshot = success_result_of(
             create_snapshot(
-                name=filename,
+                relpath=filename,
                 author=self.alice,
                 data_producer=data1,
                 snapshot_stash_dir=self.stash_dir,
@@ -380,7 +380,7 @@ class TestRemoteSnapshot(SyncTestCase):
         data2 = io.BytesIO(content2)
         child_snapshot = success_result_of(
             create_snapshot(
-                name=filename,
+                relpath=filename,
                 author=self.alice,
                 data_producer=data2,
                 snapshot_stash_dir=self.stash_dir,
@@ -395,7 +395,7 @@ class TestRemoteSnapshot(SyncTestCase):
         self.assertThat(
             reconstructed_local_snapshot,
             MatchesStructure(
-                name=Equals(filename),
+                relpath=Equals(filename),
                 parents_local=HasLength(1),
             )
         )
@@ -416,7 +416,7 @@ class TestRemoteSnapshot(SyncTestCase):
         snapshots = []
         # create LocalSnapshot
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data,
             snapshot_stash_dir=self.stash_dir,
@@ -443,7 +443,7 @@ class TestRemoteSnapshot(SyncTestCase):
         # corresponding to snapshots[0]
 
         d = create_snapshot(
-            name=filename,
+            relpath=filename,
             author=self.alice,
             data_producer=data,
             snapshot_stash_dir=self.stash_dir,
@@ -457,7 +457,7 @@ class TestRemoteSnapshot(SyncTestCase):
         self.assertThat(
             snapshots[2],
             MatchesStructure(
-                name=Equals(filename),
+                relpath=Equals(filename),
                 parents_remote=AfterPreprocessing(len, Equals(1)),
             )
         )
@@ -496,7 +496,7 @@ class TestRemoteSnapshot(SyncTestCase):
         # create LocalSnapshot
         local_snapshot = success_result_of(
             create_snapshot(
-                name=filename,
+                relpath=filename,
                 author=self.alice,
                 data_producer=data,
                 snapshot_stash_dir=self.stash_dir,
@@ -507,7 +507,7 @@ class TestRemoteSnapshot(SyncTestCase):
         # create another LocalSnapshot with the first as parent
         child_snapshot = success_result_of(
             create_snapshot(
-                name=filename,
+                relpath=filename,
                 author=self.alice,
                 data_producer=data,
                 snapshot_stash_dir=self.stash_dir,

--- a/src/magic_folder/test/test_snapshot.py
+++ b/src/magic_folder/test/test_snapshot.py
@@ -11,6 +11,7 @@ from tempfile import mktemp
 from testtools.matchers import (
     Equals,
     Contains,
+    ContainsDict,
     MatchesStructure,
     AfterPreprocessing,
     Always,
@@ -34,6 +35,7 @@ from hypothesis.strategies import (
     text,
     just,
     one_of,
+    integers,
 )
 
 from hyperlink import (
@@ -53,6 +55,7 @@ from magic_folder.testing.web import (
 
 from .common import (
     SyncTestCase,
+    success_result_of,
 )
 from .strategies import (
     magic_folder_filenames,
@@ -300,8 +303,9 @@ class TestRemoteSnapshot(SyncTestCase):
     @given(
         content=binary(min_size=1),
         filename=magic_folder_filenames(),
+        modified_time=integers(min_value=0),
     )
-    def test_snapshot_roundtrip(self, content, filename):
+    def test_snapshot_roundtrip(self, content, filename, modified_time):
         """
         Create a local snapshot, write into tahoe to create a remote snapshot,
         then read back the data from the snapshot cap to recreate the remote
@@ -309,45 +313,44 @@ class TestRemoteSnapshot(SyncTestCase):
         """
         data = io.BytesIO(content)
 
-        snapshots = []
         # create LocalSnapshot
-        d = create_snapshot(
-            name=filename,
-            author=self.alice,
-            data_producer=data,
-            snapshot_stash_dir=self.stash_dir,
-            parents=[],
-        )
-        d.addCallback(snapshots.append)
-        self.assertThat(
-            d,
-            succeeded(Always()),
+        local_snapshot = success_result_of(
+            create_snapshot(
+                name=filename,
+                author=self.alice,
+                data_producer=data,
+                snapshot_stash_dir=self.stash_dir,
+                parents=[],
+                modified_time=modified_time,
+            )
         )
 
         # create remote snapshot
-        d = write_snapshot_to_tahoe(snapshots[0], self.alice, self.tahoe_client)
-        d.addCallback(snapshots.append)
-
-        self.assertThat(
-            d,
-            succeeded(Always()),
+        remote_snapshot = success_result_of(
+            write_snapshot_to_tahoe(local_snapshot, self.alice, self.tahoe_client)
         )
 
-        # snapshots[1] is a RemoteSnapshot
-        note("remote snapshot: {}".format(snapshots[1]))
+        note("remote snapshot: {}".format(remote_snapshot))
 
         # now, recreate remote snapshot from the cap string and compare with the original.
         # Check whether information is preserved across these changes.
 
-        snapshot_d = create_snapshot_from_capability(snapshots[1].capability, self.tahoe_client)
-        snapshot_d.addCallback(snapshots.append)
-        self.assertThat(snapshot_d, succeeded(Always()))
-        snapshot = snapshots[-1]
+        downloaded_snapshot = success_result_of(
+            create_snapshot_from_capability(remote_snapshot.capability, self.tahoe_client)
+        )
 
-        self.assertThat(snapshot, MatchesStructure(name=Equals(filename)))
+        self.assertThat(
+            downloaded_snapshot,
+            MatchesStructure(
+                metadata=ContainsDict({
+                    "name": Equals(filename),
+                    "modification_time": Equals(modified_time),
+                }),
+            ),
+        )
         content_io = io.BytesIO()
         self.assertThat(
-            snapshot.fetch_content(self.tahoe_client, content_io),
+            downloaded_snapshot.fetch_content(self.tahoe_client, content_io),
             succeeded(Always()),
         )
         self.assertEqual(content_io.getvalue(), content)
@@ -363,33 +366,29 @@ class TestRemoteSnapshot(SyncTestCase):
         """
         data1 = io.BytesIO(content1)
 
-        snapshots = []
-        d = create_snapshot(
-            name=filename,
-            author=self.alice,
-            data_producer=data1,
-            snapshot_stash_dir=self.stash_dir,
-            parents=[],
-        )
-        d.addCallback(snapshots.append)
-
-        self.assertThat(
-            d,
-            succeeded(Always()),
+        local_snapshot = success_result_of(
+            create_snapshot(
+                name=filename,
+                author=self.alice,
+                data_producer=data1,
+                snapshot_stash_dir=self.stash_dir,
+                parents=[],
+            )
         )
 
         # now modify the same file and create a new local snapshot
         data2 = io.BytesIO(content2)
-        d = create_snapshot(
-            name=filename,
-            author=self.alice,
-            data_producer=data2,
-            snapshot_stash_dir=self.stash_dir,
-            parents=[snapshots[0]],
+        child_snapshot = success_result_of(
+            create_snapshot(
+                name=filename,
+                author=self.alice,
+                data_producer=data2,
+                snapshot_stash_dir=self.stash_dir,
+                parents=[local_snapshot],
+            )
         )
-        d.addCallback(snapshots.append)
 
-        serialized = snapshots[1].to_json()
+        serialized = child_snapshot.to_json()
 
         reconstructed_local_snapshot = LocalSnapshot.from_json(serialized, self.alice)
 
@@ -478,7 +477,7 @@ class TestRemoteSnapshot(SyncTestCase):
         self.assertThat(
             snapshots[3],
             MatchesStructure(
-                name=Equals(filename),
+                metadata=ContainsDict({"name": Equals(filename)}),
                 parents_raw=Equals([snapshots[1].capability]),
             )
         )
@@ -494,60 +493,51 @@ class TestRemoteSnapshot(SyncTestCase):
         """
         data = io.BytesIO(content)
 
-        snapshots = []
         # create LocalSnapshot
-        d = create_snapshot(
-            name=filename,
-            author=self.alice,
-            data_producer=data,
-            snapshot_stash_dir=self.stash_dir,
-            parents=[],
+        local_snapshot = success_result_of(
+            create_snapshot(
+                name=filename,
+                author=self.alice,
+                data_producer=data,
+                snapshot_stash_dir=self.stash_dir,
+                parents=[],
+            )
         )
-        d.addCallback(snapshots.append)
-        self.assertThat(
-            d,
-            succeeded(Always()),
-        )
-
-        # snapshots[0] is a LocalSnapshot with no parents
 
         # create another LocalSnapshot with the first as parent
-        d = create_snapshot(
-            name=filename,
-            author=self.alice,
-            data_producer=data,
-            snapshot_stash_dir=self.stash_dir,
-            parents=[snapshots[0]],
-        )
-        d.addCallback(snapshots.append)
-        self.assertThat(
-            d,
-            succeeded(Always()),
+        child_snapshot = success_result_of(
+            create_snapshot(
+                name=filename,
+                author=self.alice,
+                data_producer=data,
+                snapshot_stash_dir=self.stash_dir,
+                parents=[local_snapshot],
+            )
         )
 
         # turn them both into RemoteSnapshots
-        d = write_snapshot_to_tahoe(snapshots[1], self.alice, self.tahoe_client)
-        d.addCallback(snapshots.append)
-        self.assertThat(d, succeeded(Always()))
+        remote_snapshot = success_result_of(
+            write_snapshot_to_tahoe(child_snapshot, self.alice, self.tahoe_client)
+        )
 
         # ...the last thing we wrote is now a RemoteSnapshot and
         # should have a single parent.
         self.assertThat(
-            snapshots[2],
+            remote_snapshot,
             MatchesStructure(
-                name=Equals(filename),
+                metadata=ContainsDict({"name": Equals(filename)}),
                 parents_raw=AfterPreprocessing(len, Equals(1)),
             )
         )
 
         # turn the parent into a RemoteSnapshot
-        d = create_snapshot_from_capability(snapshots[2].parents_raw[0], self.tahoe_client)
-        d.addCallback(snapshots.append)
-        self.assertThat(d, succeeded(Always()))
+        parent_snapshot = success_result_of(
+            create_snapshot_from_capability(remote_snapshot.parents_raw[0], self.tahoe_client)
+        )
         self.assertThat(
-            snapshots[3],
+            parent_snapshot,
             MatchesStructure(
-                name=Equals(filename),
+                metadata=ContainsDict({"name": Equals(filename)}),
                 parents_raw=Equals([]),
             )
         )

--- a/src/magic_folder/test/test_upload.py
+++ b/src/magic_folder/test/test_upload.py
@@ -88,11 +88,11 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
         self.author = create_local_author(u"alice")
 
     @given(
-        name=relative_paths(),
+        relpath=relative_paths(),
         content=binary(),
         upload_dircap=tahoe_lafs_dir_capabilities(),
     )
-    def test_commit_a_file(self, name, content, upload_dircap):
+    def test_commit_a_file(self, relpath, content, upload_dircap):
         """
         Add a file into localsnapshot store, start the service which
         should result in a remotesnapshot corresponding to the
@@ -117,7 +117,7 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
         data = io.BytesIO(content)
 
         d = create_snapshot(
-            name=name,
+            relpath=relpath,
             author=self.author,
             data_producer=data,
             snapshot_stash_dir=config.stash_path,
@@ -136,7 +136,7 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
         # This should be picked up by the Uploader Service and should
         # result in a snapshot cap.
         config.store_local_snapshot(snapshots[0])
-        config.store_currentsnapshot_state(name, PathState(0, 0, 0))
+        config.store_currentsnapshot_state(relpath, PathState(0, 0, 0))
 
         remote_snapshot_creator.initialize_upload_status()
         d = remote_snapshot_creator.upload_local_snapshots()
@@ -145,13 +145,13 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
             succeeded(Always()),
         )
 
-        remote_snapshot_cap = config.get_remotesnapshot(name)
+        remote_snapshot_cap = config.get_remotesnapshot(relpath)
 
         # Verify that the new snapshot was linked in to our upload directory.
         self.assertThat(
             loads(f.root._uri.data[upload_dircap])[1][u"children"],
             Equals({
-                path2magic(name): [
+                path2magic(relpath): [
                     u"dirnode", {
                         u"ro_uri": remote_snapshot_cap.decode("utf-8"),
                         u"verify_uri": to_verify_capability(remote_snapshot_cap),
@@ -172,8 +172,8 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
             ),
         )
 
-        with ExpectedException(KeyError, escape(repr(name))):
-            config.get_local_snapshot(name)
+        with ExpectedException(KeyError, escape(repr(relpath))):
+            config.get_local_snapshot(relpath)
 
     @given(
         path_segments(),
@@ -184,7 +184,7 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
         ),
         tahoe_lafs_dir_capabilities(),
     )
-    def test_write_snapshot_to_tahoe_fails(self, name, contents, upload_dircap):
+    def test_write_snapshot_to_tahoe_fails(self, relpath, contents, upload_dircap):
         """
         If any part of a snapshot upload fails then the metadata for that snapshot
         is retained in the local database and the snapshot content is retained
@@ -206,7 +206,7 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
         for content in contents:
             data = io.BytesIO(content)
             d = create_snapshot(
-                name=name,
+                relpath=relpath,
                 author=self.author,
                 data_producer=data,
                 snapshot_stash_dir=config.stash_path,
@@ -233,7 +233,7 @@ class RemoteSnapshotCreatorTests(SyncTestCase):
 
         self.assertEqual(
             local_snapshot,
-            config.get_local_snapshot(name),
+            config.get_local_snapshot(relpath),
         )
         self.assertThat(
             local_snapshot.content_path.getContent(),

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -295,7 +295,7 @@ class RemoteSnapshotCreator(object):
         format to LocalSnapshot objects and commit them into the grid.
         """
 
-        # get the mangled paths for the LocalSnapshot objects in the db
+        # get the paths for the LocalSnapshot objects in the db
         localsnapshot_names = self._config.get_all_localsnapshot_paths()
 
         # XXX: processing this table should be atomic. i.e. While the upload is

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -336,7 +336,7 @@ class RemoteSnapshotCreator(object):
         )
         Message.log(message_type="snapshot:metadata",
                     metadata=remote_snapshot.metadata,
-                    name=remote_snapshot.name,
+                    name=name,
                     capability=remote_snapshot.capability)
 
         # if we crash here, we'll retry and re-upload (hopefully

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -455,13 +455,13 @@ class APIv1(object):
 
         return json.dumps([
             {
-                "relpath": name,
+                "relpath": relpath,
                 "mtime": ns_to_seconds(ps.mtime_ns),
                 "last-updated": ns_to_seconds(last_updated_ns),
                 "last-upload-duration": float(upload_duration_ns) / 1000000000.0 if upload_duration_ns else None,
                 "size": ps.size,
             }
-            for name, ps, last_updated_ns, upload_duration_ns
+            for relpath, ps, last_updated_ns, upload_duration_ns
             in folder_config.get_all_current_snapshot_pathstates()
         ])
 


### PR DESCRIPTION
@meejah This is the followup to #500 that we discussed.

- Don't pass snapshot to IMagicFileSystem.
- Remove .name from RemoteSnapshot.

Once #500 lands, I'll re-target this to main, but for the moment, it is against the current (as of this PR being opened) state of #500.