### PR TITLE
524.tahoe objects

### DIFF
--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -192,6 +192,14 @@ The list is ordered from most-recent to least-recent timestamp.
 ``size`` is in bytes.
 
 
+GET `/v1/magic-folder/<folder-name>/tahoe-objects`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns a list of integers representing the sizes of all individual capabilities that this folder is using.
+That means a size for each Snapshot capability and its corresponding metadata capability and content capability.
+The list is flat; if there are 2 Snapshots on the grid this will return 6 integers.
+
+
 Status API
 ----------
 

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1053,10 +1053,16 @@ class MagicFolderConfig(object):
                 action.add_success_fields(insert_or_update="insert")
             except (sqlite3.IntegrityError, sqlite3.OperationalError):
                 cursor.execute(
-                    "UPDATE current_snapshots"
-                    " SET snapshot_cap=?, mtime_ns=?, ctime_ns=?, size=?, last_updated_ns=?, metadata_cap?, content_cap=?"
-                    " WHERE [name]=?",
-                    (snapshot_cap, path_state.mtime_ns, path_state.ctime_ns, path_state.size, now_ns, name, remote_snapshot.metadata_cap, remote_snapshot.content_cap),
+                    """
+                    UPDATE
+                        current_snapshots
+                    SET
+                        snapshot_cap=?, mtime_ns=?, ctime_ns=?, size=?, last_updated_ns=?, metadata_cap=?, content_cap=?
+                    WHERE
+                        [name]=?
+                    """,
+                    (snapshot_cap, path_state.mtime_ns, path_state.ctime_ns, path_state.size,
+                     now_ns, remote_snapshot.metadata_cap, remote_snapshot.content_cap, name),
                 )
                 action.add_success_fields(insert_or_update="update")
 

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1146,6 +1146,42 @@ class MagicFolderConfig(object):
                 return row[0].encode("utf-8")
             raise KeyError(name)
 
+
+    @with_cursor
+    def get_remotesnapshot_caps(self, cursor, name):
+        """
+        return all three capabilities corresponding to a given remote snapshot
+
+        :param unicode name: The name to match.  See ``LocalSnapshot.name``.
+
+        :raise KeyError: If no snapshot exists for the given name.
+
+        :returns: A 3-tuple of (snapshot-cap, content-cap, metadata-cap)
+        """
+        action = FETCH_CURRENT_SNAPSHOTS_FROM_DB(
+            relpath=name,
+        )
+        with action:
+            cursor.execute(
+                """
+                SELECT
+                    snapshot_cap, content_cap, metadata_cap
+                FROM
+                    current_snapshots
+                WHERE
+                    [name]=?
+                """,
+                (name,)
+            )
+            row = cursor.fetchone()
+            if row and row[0] is not None:
+                return (
+                    row[0].encode("utf-8"),  # snapshot-cap
+                    row[1].encode("utf-8"),  # content-cap
+                    row[2].encode("utf-8"),  # metadata-cap
+                )
+            raise KeyError(name)
+
     @with_cursor
     def get_currentsnapshot_pathstate(self, cursor, name):
         """

--- a/src/magic_folder/snapshot.py
+++ b/src/magic_folder/snapshot.py
@@ -367,10 +367,11 @@ class RemoteSnapshot(object):
 
     name = attr.ib()
     author = attr.ib()  # any SnapshotAuthor instance
-    metadata = attr.ib()
-    capability = attr.ib()
+    metadata = attr.ib()  # deserialied metadata
+    capability = attr.ib()  # immutable dir-cap
     parents_raw = attr.ib()
-    content_cap = attr.ib()
+    content_cap = attr.ib()  # immutable capability
+    metadata_cap = attr.ib()  # immutable capability
 
     @inline_callbacks
     def fetch_content(self, tahoe_client, writable_file):
@@ -444,6 +445,7 @@ def create_snapshot_from_capability(snapshot_cap, tahoe_client):
             author=author,
             metadata=metadata,
             content_cap=content_cap,
+            metadata_cap=metadata_cap,
             parents_raw=parent_caps,
             capability=snapshot_cap.decode("ascii"),
         )
@@ -666,6 +668,7 @@ def write_snapshot_to_tahoe(snapshot, author_key, tahoe_client):
             parents_raw=parents_raw,
             capability=snapshot_cap.decode("ascii"),
             content_cap=content_cap,
+            metadata_cap=metadata_cap,
         )
     )
 

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -413,6 +413,7 @@ def remote_snapshots(names=path_segments(), authors=remote_authors()):
         capability=tahoe_lafs_immutable_dir_capabilities(),
         parents_raw=lists(tahoe_lafs_immutable_dir_capabilities()),
         content_cap=tahoe_lafs_chk_capabilities(),
+        metadata_cap=tahoe_lafs_chk_capabilities(),
     )
 
 

--- a/src/magic_folder/test/test_api_cli.py
+++ b/src/magic_folder/test/test_api_cli.py
@@ -575,6 +575,7 @@ class TestDumpState(AsyncTestCase):
                 capability="URI:DIR2-CHK:l7b3rn6pha6c2ipbbo4yxvunvy:c6ppejrkip4cdfo3kmyju36qbb6bbptzhh3pno7jb5b5myzoxkja:1:5:329",
                 parents_raw=[],
                 content_cap="URI:CHK2:yyyyyyyyyyyyyyyy:zzzzzzzzzzzzzzzz:1:1:256",
+                metadata_cap="URI:CHK2:yyyyyyyyyyyyyyyy:zzzzzzzzzzzzzzzz:1:1:256",
             ),
             PathState(
                 0,

--- a/src/magic_folder/test/test_config.py
+++ b/src/magic_folder/test/test_config.py
@@ -806,7 +806,8 @@ class RemoteSnapshotTimeTests(SyncTestCase):
                 {"modification_time": x},
                 "URI:DIR2-CHK:",
                 [],
-                "URI:DIR2-CHK:",
+                "URI:CHK:",
+                "URI:CHK:",
             )
             # XXX this seems fraught; have to remember to call two
             # APIs or we get exceptions / inconsistent state...

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -725,6 +725,7 @@ class ConflictTests(AsyncTestCase):
             capability=cap0,
             parents_raw=[],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[cap0] = remote0
 
@@ -770,6 +771,7 @@ class ConflictTests(AsyncTestCase):
             capability=parent_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         parent_content = b"parent" * 1000
         self.remote_cache._cached_snapshots[parent_cap] = parent
@@ -785,6 +787,7 @@ class ConflictTests(AsyncTestCase):
             capability=cap0,
             parents_raw=[parent_cap],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[cap0] = remote0
 
@@ -823,6 +826,7 @@ class ConflictTests(AsyncTestCase):
                 capability=parent_cap,
                 parents_raw=[] if not remotes else [remotes[-1].capability],
                 content_cap=b"URI:CHK:",
+                metadata_cap=b"URI:CHK:",
             )
             self.remote_cache._cached_snapshots[parent_cap] = parent
             remotes.append(parent)
@@ -862,6 +866,7 @@ class ConflictTests(AsyncTestCase):
             capability=parent_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[parent_cap] = parent
 
@@ -873,6 +878,7 @@ class ConflictTests(AsyncTestCase):
             capability=child_cap,
             parents_raw=[parent_cap],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[child_cap] = child
 
@@ -884,6 +890,7 @@ class ConflictTests(AsyncTestCase):
             capability=other_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[other_cap] = other
 
@@ -919,6 +926,7 @@ class ConflictTests(AsyncTestCase):
             capability=parent_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[parent_cap] = parent
 
@@ -930,6 +938,7 @@ class ConflictTests(AsyncTestCase):
             capability=child_cap,
             parents_raw=[parent_cap],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[child_cap] = child
 
@@ -963,6 +972,7 @@ class ConflictTests(AsyncTestCase):
             capability=parent_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[parent_cap] = parent
 
@@ -1042,6 +1052,7 @@ class ConflictTests(AsyncTestCase):
             capability=parent_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
+            metadata_cap=b"URI:CHK:",
         )
         self.remote_cache._cached_snapshots[parent_cap] = parent
 

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -103,6 +103,7 @@ class FindUpdatesTests(SyncTestCase):
             capability="URI:DIR2-CHK:",
             parents_raw=[],
             content_cap="URI:CHK:",
+            metadata_cap="URI:CHK:",
         )
         self.config.store_downloaded_snapshot(
             path2magic(name), snap, get_pathinfo(local).state
@@ -138,6 +139,7 @@ class FindUpdatesTests(SyncTestCase):
             capability="URI:DIR2-CHK:",
             parents_raw=[],
             content_cap="URI:CHK:",
+            metadata_cap="URI:CHK:",
         )
         self.config.store_downloaded_snapshot(
             path2magic(name),

--- a/src/magic_folder/util/capabilities.py
+++ b/src/magic_folder/util/capabilities.py
@@ -15,6 +15,16 @@ from allmydata.uri import (
 from allmydata.uri import from_string as tahoe_uri_from_string
 
 
+def cap_size(capability):
+    """
+    :returns: the size, in bytes, of the capability
+    """
+    uri = tahoe_uri_from_string(capability)
+    if IDirnodeURI.providedBy(uri):
+        return uri.get_filenode_cap().get_size()
+    return uri.get_size()
+
+
 def is_directory_cap(capability):
     """
     :returns: True if `capability` is a directory-cap of any sort

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -67,7 +67,10 @@ from .snapshot import (
 from .participants import (
     participants_from_collective,
 )
-from .util.capabilities import is_readonly_directory_cap
+from .util.capabilities import (
+    is_readonly_directory_cap,
+    cap_size,
+)
 from .util.file import (
     ns_to_seconds,
 )
@@ -466,6 +469,30 @@ class APIv1(object):
             for name, ps, last_updated_ns
             in folder_config.get_all_current_snapshot_pathstates()
         ])
+
+    @app.route("/magic-folder/<string:folder_name>/tahoe-objects", methods=['GET'])
+    def folder_tahoe_objects(self, request, folder_name):
+        """
+        Renders a list of all the object-sizes of all Tahoe objects a
+        given magic-folder currently cares about. This is, for each
+        Snapshot: the Snapshot capability, the metadata capability and
+        the content capability.
+        """
+        _application_json(request)  # set reply headers
+        folder_config = self._global_config.get_magic_folder(folder_name)
+
+        snapshots = folder_config.get_all_snapshot_paths()
+        caps = [
+            folder_config.get_remotesnapshot_caps(name)
+            for name in snapshots
+        ]
+        sizes = []
+        for cap in caps:
+            sizes.extend([
+                cap_size(c)
+                for c in cap
+            ])
+        return json.dumps(sizes)
 
 
 class _InputError(APIError):


### PR DESCRIPTION
Add a `.../tahoe-objects` API to retrieve the sizes of all Tahoe objects we care about.

The immediate use-case for this is to pass to ZKAPAuthorizer to compute how much it will cost to renew the leases on all of them.