### PR TITLE
Enable PEP 518 build isolation.

### DIFF
--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -85,9 +85,11 @@ process_eliot_logs() {
 
 trap 'process_eliot_logs' EXIT
 
+# Skip install here, as we've already done it in setup-virtualenv.sh
 ${TIMEOUT} "${BOOTSTRAP_VENV}"/bin/tox \
     -c "${PROJECT_ROOT}"/tox.ini \
     --workdir /tmp/magic-folder.tox \
+    --skip-pkg-install \
     -e "${MAGIC_FOLDER_TOX_ENVIRONMENT}" \
     ${MAGIC_FOLDER_TOX_ARGS} || "${alternative}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools<45", "wheel"]
+
 [tool.towncrier]
     package_dir = "src"
     package = "magic_folder"

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,6 @@ def load_requirements(filename):
 install_requires = load_requirements("base.in")
 test_requires = load_requirements("test.in")
 
-setup_requires = [
-    'setuptools >= 28.8.0, <45',  # for PEP-440 style versions
-]
-
 from setuptools import find_packages, setup
 from setuptools import Command
 
@@ -103,7 +99,6 @@ setup(name="magic_folder",
       package_data={"magic_folder": ["ported-modules.txt"],
                     },
       include_package_data=True,
-      setup_requires=setup_requires,
       entry_points={
           "console_scripts": [
               "magic-folder = magic_folder.cli:_entry",

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ passenv = MAGIC_FOLDER_* PIP_* SUBUNITREPORTER_* USERPROFILE HOMEDRIVE HOMEPATH
 deps =
      -r requirements/tox.txt
 
+isolated_build = True
 # We add usedevelop=False because testing against a true installation gives
 # more useful results.
 usedevelop = False


### PR DESCRIPTION
This is in preparation for #547, as black uses `pyproject.toml` as its configuration file.