### PR TITLE
513.upload sooner

### DIFF
--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1084,7 +1084,7 @@ class MagicFolderConfig(object):
     def get_all_snapshot_paths(self, cursor):
         """
         Retrieve a set of all relpaths of files that have had an entry in magic folder db
-        (i.e. that have been downloaded at least once).
+        (i.e. that have been downloaded or uploaded at least once).
         """
         cursor.execute("SELECT [name] FROM [current_snapshots]")
         rows = cursor.fetchall()

--- a/src/magic_folder/magic_folder.py
+++ b/src/magic_folder/magic_folder.py
@@ -85,17 +85,6 @@ class MagicFolder(service.MultiService):
             config=mf_config,
             tahoe_client=tahoe_client,
         )
-        local_snapshot_service = LocalSnapshotService(
-            mf_config,
-            LocalSnapshotCreator(
-                mf_config,
-                mf_config.author,
-                mf_config.stash_path,
-                mf_config.magic_path,
-                tahoe_client,
-            ),
-            status=folder_status,
-        )
         uploader_service = UploaderService.from_config(
             clock=reactor,
             config=mf_config,
@@ -107,11 +96,22 @@ class MagicFolder(service.MultiService):
                 status=folder_status,
             ),
         )
+        local_snapshot_service = LocalSnapshotService(
+            mf_config,
+            LocalSnapshotCreator(
+                mf_config,
+                mf_config.author,
+                mf_config.stash_path,
+                mf_config.magic_path,
+                tahoe_client,
+            ),
+            status=folder_status,
+            uploader_service=uploader_service,
+        )
         scanner_service = ScannerService.from_config(
             reactor,
             mf_config,
             local_snapshot_service,
-            uploader_service,
             status=folder_status,
         )
 

--- a/src/magic_folder/magic_folder.py
+++ b/src/magic_folder/magic_folder.py
@@ -96,10 +96,22 @@ class MagicFolder(service.MultiService):
             ),
             status=folder_status,
         )
+        uploader_service = UploaderService.from_config(
+            clock=reactor,
+            config=mf_config,
+            remote_snapshot_creator=RemoteSnapshotCreator(
+                config=mf_config,
+                local_author=mf_config.author,
+                tahoe_client=tahoe_client,
+                upload_dircap=mf_config.upload_dircap,
+                status=folder_status,
+            ),
+        )
         scanner_service = ScannerService.from_config(
             reactor,
             mf_config,
             local_snapshot_service,
+            uploader_service,
             status=folder_status,
         )
 
@@ -108,17 +120,7 @@ class MagicFolder(service.MultiService):
             config=mf_config,
             name=name,
             local_snapshot_service=local_snapshot_service,
-            uploader_service=UploaderService.from_config(
-                clock=reactor,
-                config=mf_config,
-                remote_snapshot_creator=RemoteSnapshotCreator(
-                    config=mf_config,
-                    local_author=mf_config.author,
-                    tahoe_client=tahoe_client,
-                    upload_dircap=mf_config.upload_dircap,
-                    status=folder_status,
-                ),
-            ),
+            uploader_service=uploader_service,
             remote_snapshot_cache=remote_snapshot_cache_service,
             downloader=DownloaderService.from_config(
                 name=name,

--- a/src/magic_folder/scanner.py
+++ b/src/magic_folder/scanner.py
@@ -117,6 +117,7 @@ class ScannerService(MultiService):
                 # implementation there...
                 self._uploader_service.perform_upload()
                 return arg
+            d.addCallback(made_snapshot)
             results.append(d)
 
         # XXX update/use IStatus to report scan start/end

--- a/src/magic_folder/scanner.py
+++ b/src/magic_folder/scanner.py
@@ -110,6 +110,13 @@ class ScannerService(MultiService):
             d = self._local_snapshot_service.add_file(path)
             d.addErrback(write_failure)
 
+            # it might be slightly better to do this in
+            # e.g. LocalSnapshotService, but that has implications for
+            # test-ability and changes the "create a snapshot"
+            # low-level API to also mean "..and start uploading". See
+            # also
+            # https://github.com/LeastAuthority/magic-folder/issues/542
+
             def made_snapshot(arg):
                 # maybe start an upload .. actually doesn't check
                 # first, so this will stack up one "do an upload" per
@@ -127,8 +134,6 @@ class ScannerService(MultiService):
                 self._cooperator, self._config, process, status=self._status
             )
             yield gatherResults(results)
-        # if we aren't already doing uploads, start some now
-        self._uploader_service.perform_upload()
 
 
 def find_updated_files(cooperator, folder_config, on_new_file, status):

--- a/src/magic_folder/scanner.py
+++ b/src/magic_folder/scanner.py
@@ -109,6 +109,14 @@ class ScannerService(MultiService):
         def process(path):
             d = self._local_snapshot_service.add_file(path)
             d.addErrback(write_failure)
+
+            def made_snapshot(arg):
+                # maybe start an upload .. actually doesn't check
+                # first, so this will stack up one "do an upload" per
+                # file scanned because of the lock-based
+                # implementation there...
+                self._uploader_service.perform_upload()
+                return arg
             results.append(d)
 
         # XXX update/use IStatus to report scan start/end

--- a/src/magic_folder/test/cli/test_api_cli.py
+++ b/src/magic_folder/test/cli/test_api_cli.py
@@ -82,7 +82,7 @@ class ScanMagicFolder(AsyncTestCase):
             Equals(True),
         )
 
-        snapshot_paths = self.folder_config.get_all_localsnapshot_paths()
+        snapshot_paths = self.folder_config.get_all_snapshot_paths()
         self.assertThat(
             snapshot_paths,
             Equals({name}),

--- a/src/magic_folder/test/test_local_snapshot.py
+++ b/src/magic_folder/test/test_local_snapshot.py
@@ -91,6 +91,12 @@ class MemorySnapshotCreator(object):
         )
         self.processed.append(path)
 
+class MemoryUploaderService(object):
+    upload_requested = False
+    def perform_upload(self):
+        self.upload_requested = True
+        return defer.Deferred()
+
 
 class LocalSnapshotServiceTests(SyncTestCase):
     """
@@ -121,10 +127,12 @@ class LocalSnapshotServiceTests(SyncTestCase):
 
         self.status = WebSocketStatusService(reactor, self._global_config)
         self.snapshot_creator = MemorySnapshotCreator()
+        self.uploader_service = MemoryUploaderService()
         self.snapshot_service = LocalSnapshotService(
             config=self.magic_config,
             snapshot_creator=self.snapshot_creator,
             status=FolderStatus(self.magic_config.name, self.status),
+            uploader_service=self.uploader_service,
         )
 
 
@@ -152,6 +160,11 @@ class LocalSnapshotServiceTests(SyncTestCase):
         self.assertThat(
             self.snapshot_creator.processed,
             Equals([to_add]),
+        )
+
+        self.assertThat(
+            self.uploader_service.upload_requested,
+            Equals(True)
         )
 
     @given(lists(path_segments(), unique=True),

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -260,7 +260,6 @@ class MagicFolderFromConfigTests(SyncTestCase):
         just(LOCAL_AUTHOR),
         sampled_from([b"URI:DIR2:", b"URI:DIR2-RO:"]),
         integers(min_value=1, max_value=10000),
-        one_of(integers(min_value=1, max_value=10000), none()),
         binary(),
     )
     def test_uploader_service(
@@ -270,7 +269,6 @@ class MagicFolderFromConfigTests(SyncTestCase):
             author,
             collective_cap_kind,
             poll_interval,
-            scan_interval,
             content,
     ):
         """
@@ -278,6 +276,7 @@ class MagicFolderFromConfigTests(SyncTestCase):
         upload snapshots using the given Tahoe client object.
         """
         reactor = task.Clock()
+        scan_interval = None
 
         root = create_fake_tahoe_root()
         http_client = create_tahoe_treq_client(root)

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -79,6 +79,7 @@ from .strategies import (
 )
 from .test_local_snapshot import (
     MemorySnapshotCreator,
+    MemoryUploaderService,
 )
 
 class MagicFolderServiceTests(SyncTestCase):
@@ -153,6 +154,7 @@ class MagicFolderServiceTests(SyncTestCase):
             mf_config,
             local_snapshot_creator,
             folder_status,
+            MemoryUploaderService(),
         )
 
         tahoe_client = object()
@@ -216,6 +218,7 @@ class MagicFolderServiceTests(SyncTestCase):
             config,
             local_snapshot_creator,
             folder_status,
+            uploader_service=Service(),
         )
 
         # create RemoteSnapshotCreator and UploaderService
@@ -350,8 +353,7 @@ class MagicFolderFromConfigTests(SyncTestCase):
             Equals(name),
         )
 
-        # add a file. This won't actually add a file until we advance
-        # the clock.
+        # add a file.
         d = magic_folder.local_snapshot_service.add_file(
             target_path,
         )
@@ -363,15 +365,6 @@ class MagicFolderFromConfigTests(SyncTestCase):
 
         def children():
             return json.loads(root._uri.data[upload_dircap])[1][u"children"]
-
-        reactor.advance(poll_interval - 1)
-
-        self.assertThat(
-            children(),
-            Equals({}),
-        )
-
-        reactor.advance(1)
 
         self.assertThat(
             children(),

--- a/src/magic_folder/test/test_magic_folder_service.py
+++ b/src/magic_folder/test/test_magic_folder_service.py
@@ -31,8 +31,6 @@ from hypothesis.strategies import (
     binary,
     integers,
     just,
-    none,
-    one_of,
     sampled_from,
 )
 from testtools.matchers import (

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -192,9 +192,14 @@ class FindUpdatesTests(SyncTestCase):
                 files.append(f)
                 return succeed(None)
 
+        class UploaderService(object):
+            def perform_upload(self):
+                pass
+
         service = ScannerService(
             self.config,
             SnapshotService(),
+            UploaderService(),
             object(),
             cooperator=self.cooperator,
             scan_interval=None,
@@ -229,9 +234,14 @@ class FindUpdatesTests(SyncTestCase):
                 files.append(f)
                 return succeed(None)
 
+        class UploaderService(object):
+            def perform_upload(self):
+                pass
+
         service = ScannerService(
             self.config,
             SnapshotService(),
+            UploaderService(),
             object(),
             cooperator=self.cooperator,
             scan_interval=1,

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -7,7 +7,7 @@ Tests relating generally to magic_folder.scanner
 from hypothesis import given
 from testtools.matchers import Always, Equals
 from testtools.twistedsupport import succeeded
-from twisted.internet.defer import succeed
+from twisted.internet.defer import succeed, DeferredList, Deferred
 from twisted.internet.task import Cooperator
 from twisted.python.filepath import FilePath
 
@@ -213,6 +213,60 @@ class FindUpdatesTests(SyncTestCase):
         )
 
         self.assertThat(files, Equals([local]))
+
+
+    def test_overlapping_scans(self):
+        """
+        The scanner will not perform more than one scan at the same time
+        """
+        self.setup_example()  # no @given() on this test
+        performed_uploads = []
+
+        class SnapshotService(object):
+            def add_file(self, f):
+                return succeed(None)
+
+        class RemoteSnapshotCreator(object):
+            def initialize_upload_status(self):
+                pass
+
+            def upload_local_snapshots(self):
+                # these get "completed" below
+                d = Deferred()
+                performed_uploads.append(d)
+                return d
+
+        # we want to test the "real" uploader-service here (but use a
+        # fake snapshot-creator so there's no actual work performed)
+        from magic_folder.uploader import UploaderService
+
+        service = ScannerService(
+            self.config,
+            SnapshotService(),
+            UploaderService(
+                clock=object(),
+                poll_interval=1,
+                remote_snapshot_creator=RemoteSnapshotCreator(),
+            ),
+            object(),
+            cooperator=self.cooperator,
+            scan_interval=None,
+        )
+        service.startService()
+        self.addCleanup(service.stopService)
+
+        # initiate 5 scans "at once"
+        scans = [
+            service.scan_once()
+            for _ in range(5)
+        ]
+
+        # pretend the "actual" uploads completed now (although there
+        # should be only one that actually got intiated; see assert)
+        for d in performed_uploads:
+            d.callback(None)
+
+        self.assertThat(len(performed_uploads), Equals(1))
 
     @given(
         relative_paths(),

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -266,14 +266,9 @@ class FindUpdatesTests(SyncTestCase):
                 files.append(f)
                 return succeed(None)
 
-        class UploaderService(object):
-            def perform_upload(self):
-                pass
-
         service = ScannerService(
             self.config,
             SnapshotService(),
-            UploaderService(),
             object(),
             cooperator=self.cooperator,
             scan_interval=None,
@@ -308,14 +303,9 @@ class FindUpdatesTests(SyncTestCase):
                 files.append(f)
                 return succeed(None)
 
-        class UploaderService(object):
-            def perform_upload(self):
-                pass
-
         service = ScannerService(
             self.config,
             SnapshotService(),
-            UploaderService(),
             object(),
             cooperator=self.cooperator,
             scan_interval=1,

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -7,7 +7,7 @@ Tests relating generally to magic_folder.scanner
 from hypothesis import given
 from testtools.matchers import Always, Equals
 from testtools.twistedsupport import succeeded
-from twisted.internet.defer import succeed, DeferredList, Deferred
+from twisted.internet.defer import succeed, Deferred
 from twisted.internet.task import Cooperator
 from twisted.python.filepath import FilePath
 
@@ -256,10 +256,8 @@ class FindUpdatesTests(SyncTestCase):
         self.addCleanup(service.stopService)
 
         # initiate 5 scans "at once"
-        scans = [
+        for _ in range(5):
             service.scan_once()
-            for _ in range(5)
-        ]
 
         # pretend the "actual" uploads completed now (although there
         # should be only one that actually got intiated; see assert)

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -13,7 +13,7 @@ from testtools.matchers import (
     MatchesStructure,
 )
 from testtools.twistedsupport import succeeded
-from twisted.internet.defer import succeed, Deferred
+from twisted.internet.defer import succeed
 from twisted.internet.task import Clock, Cooperator
 from twisted.python import runtime
 from twisted.python.filepath import FilePath

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -1021,7 +1021,7 @@ class ScanFolderTests(SyncTestCase):
         )
 
         folder_config = node.global_config.get_magic_folder(folder_name)
-        snapshot_paths = folder_config.get_all_localsnapshot_paths()
+        snapshot_paths = folder_config.get_all_snapshot_paths()
         self.assertThat(
             snapshot_paths,
             Equals({path2magic(path_in_folder)}),

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -324,7 +324,6 @@ class RemoteSnapshotCreator(object):
             except Exception:
                 write_traceback()
 
-
     @inline_callbacks
     def _upload_some_snapshots(self, name):
         """

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -448,10 +448,6 @@ class UploaderService(service.Service):
         if self._uploading:
             return
 
-        def err(fail):
-            print(fail)
-            return None
-
         def reset_upload(arg):
             self._uploading = False
             return arg
@@ -459,7 +455,7 @@ class UploaderService(service.Service):
         d = maybeDeferred(self._remote_snapshot_creator.upload_local_snapshots)
         self._uploading = True
         d.addBoth(reset_upload)
-        d.addErrback(err)
+        return d
 
     def stopService(self):
         """

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -168,7 +168,7 @@ class APIv1(object):
         this Magic Folder service.
     """
     _global_config = attr.ib()
-    _global_service = attr.ib()
+    _global_service = attr.ib()  # MagicFolderService instance
     _status_service = attr.ib(validator=attr.validators.provides(IStatus))
     _tahoe_client = attr.ib()
 


### PR DESCRIPTION
Fixes #513 

After a scan (whether timer-based or due to the HTTP API) we will initiate an upload immediately unless one is already happening.
