### PR TITLE
538.conflicts db api

### DIFF
--- a/docs/proposed/conflict-api.rst
+++ b/docs/proposed/conflict-api.rst
@@ -58,6 +58,15 @@ Returns a list (possibly empty) of local filesystem paths corresponding to each 
 Our content is in the path itself.
 The conflicting "other" content is in ``<path>.conflict-<name>`` where ``<name>`` is the petname of the participant who is provided the conflicted content.
 
+This endpoint returns a JSON dict mapping any local conflicted ``relpath`` to a list of authors.
+Following this example::
+
+    {
+        "foo": ["laptop"]
+    }
+
+This indicates that a single file ``foo`` has a conflict with a single other participant ``laptop``.
+
 
 
 ``POST /v1/magic-folder/<folder-name>/resolve-conflict

--- a/integration/util.py
+++ b/integration/util.py
@@ -291,7 +291,7 @@ class MagicFolderEnabledNode(object):
                 folder_name, None
             )
             if folder_config is not None:
-                folder_config.database.close()
+                folder_config._database.close()
 
         return _magic_folder_runner(
             self.reactor, self.request, self.name,

--- a/newsfragments/538.feature
+++ b/newsfragments/538.feature
@@ -1,0 +1,1 @@
+Add an explicit 'conflicts' API

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1263,8 +1263,6 @@ class MagicFolderConfig(object):
                 (relpath, ),
             )
             rows = cursor.fetchall()
-            if not rows:
-                return None
             return [
                 Conflict(snap_cap, author_name)
                 for author_name, snap_cap in rows

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1225,6 +1225,31 @@ class MagicFolderConfig(object):
             return conflicts
 
     @with_cursor
+    def list_conflicts_for(self, cursor, name):
+        """
+        :param text name: snapshot name
+
+        :returns dict: map of relpaths to a list of the author-names of
+            all participants that conflict with that path.
+        """
+        with start_action(action_type="config:state-db:list-conflicts"):
+            cursor.execute(
+                """
+                SELECT
+                    conflict_author
+                FROM
+                    conflicted_files
+                WHERE
+                    name=?
+                """,
+                (name, ),
+            )
+            rows = cursor.fetchall()
+            if not rows:
+                return None
+            return [row[0] for row in rows]
+
+    @with_cursor
     def add_conflict(self, cursor, name, author):
         """
         Add a new conflicting author

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1317,11 +1317,14 @@ class MagicFolderConfig(object):
         relpath = u"/".join(path.segmentsFrom(self.magic_path))
         m = _conflict_file_re.match(relpath)
         if m:
-            base, author = m.group(1), m.group(2)
-            # XXX we could check our database here to see if there's
-            # _actually_ a conflict on this file currently .. but it
-            # might be extra-confusing if we "sometimes" consider a
-            # file that matches the pattern to be not-a-conflict
+            # the plain relpath is .group(1)
+            # the author-name is .group(2)
+            #
+            # using the above, we could check our database here to see
+            # if there's _actually_ a conflict on this file currently
+            # .. but it might be extra-confusing if we "sometimes"
+            # consider a file that matches the pattern to be
+            # not-a-conflict
             return True
         return False
 

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -222,7 +222,7 @@ _magicfolder_config_schema = Schema([
         -- This table represents the current state of the file on disk, as last known to us
         CREATE TABLE [current_snapshots]
         (
-            [realpath]         TEXT PRIMARY KEY, -- snapshot name (mangled path) in UTF-8
+            [relpath]          TEXT PRIMARY KEY, -- snapshot relative-path in UTF-8
             [snapshot_cap]     TEXT,             -- Tahoe-LAFS URI that represents the most recent remote snapshot
                                                  -- associated with this file, either as downloaded from a peer
                                                  -- or uploaded from local changes
@@ -1213,7 +1213,7 @@ class MagicFolderConfig(object):
             cursor.execute(
                 """
                 SELECT
-                    name, conflict_author
+                    relpath, conflict_author
                 FROM
                     conflicted_files
                 """

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -238,10 +238,12 @@ _magicfolder_config_schema = Schema([
         --- on disk, our representation is canonical as the filesystem is part of the API)
         CREATE TABLE [conflicted_files]
         (
-            [name]             TEXT NOT NULL,    -- mangled name in UTF-8
-            [conflict_author]  TEXT NOT NULL     -- another participant who conflicts
+            [relpath]          TEXT NOT NULL,      -- mangled name in UTF-8
+            [conflict_author]  TEXT NOT NULL,      -- another participant who conflicts
+            PRIMARY KEY(relpath, conflict_author)  -- unique rows
         )
-        --- note that a single name may appear more than once if there are multiple conflicts
+        --- note that a single relpath may appear more than once if there are multiple
+        --- conflicts (i.e. multiple other devices conflict)
         """
     ]),
 ])

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1245,7 +1245,7 @@ class MagicFolderConfig(object):
     @with_cursor
     def list_conflicts_for(self, cursor, relpath):
         """
-        :param text relpath: snapshot relpath
+        :param unicode relpath: snapshot relative path
 
         :returns list: list of Conflict instances, or None if there
             are no conflicts at all for `relpath`

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1267,8 +1267,8 @@ class MagicFolderConfig(object):
             rows = cursor.fetchall()
             if not rows:
                 return None
-            all_caps = [row[1] for row in rows]
-            assert len(set(all_caps)) == 1, "Conflicts with different capabilities"
+            all_capabilities = [row[1] for row in rows]
+            assert len(set(all_capabilities)) == 1, "Conflicts with different capabilities"
             return Conflict(
                 snapshot_cap=rows[0][1],
                 author_names=[row[0] for row in rows],
@@ -1293,6 +1293,9 @@ class MagicFolderConfig(object):
                 """,
                 (snapshot.relpath,),
             )
+            # XXX maybe there's a "database way" to keep this
+            # consistent? sqlite docs say CHECK() can't contain a
+            # sub-query though
             for row in cursor.fetchall():
                 assert snapshot.capability == row[0], "conflict capability mismatch"
             cursor.execute(

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1233,14 +1233,14 @@ class MagicFolderConfig(object):
                 """
             )
             conflicts = dict()
-            for row in cursor.fetchall():
+            for relpath, author_name, snap_cap in cursor.fetchall():
                 try:
-                    conflicts[row[0]].author_names.append(row[1])
-                    assert row[2] == conflicts[row[0]].snapshot_cap, "Capabilities don't match"
+                    conflicts[relpath].author_names.append(author_name)
+                    assert snap_cap == conflicts[relpath].snapshot_cap, "Capabilities don't match"
                 except KeyError:
-                    conflicts[row[0]] = Conflict(
-                        snapshot_cap=row[2],
-                        author_names=[row[1]],
+                    conflicts[relpath] = Conflict(
+                        snapshot_cap=snap_cap,
+                        author_names=[author_name],
                     )
             return conflicts
 

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -1291,7 +1291,9 @@ class MagicFolderConfig(object):
     @with_cursor
     def resolve_conflict(self, cursor, relpath):
         """
-        Delete all conflicts for a given Snapshot relpath.
+        Delete all conflicts for a given Snapshot relpath. Note that this
+        doesn't delete any conflict marker files only modifies the
+        state database.
 
         :param text relpath: The relpath of an existing Snapshot.
         """

--- a/src/magic_folder/config.py
+++ b/src/magic_folder/config.py
@@ -252,6 +252,8 @@ _magicfolder_config_schema = Schema([
     ]),
 ])
 
+
+# matches conflict marker files; see is_conflict_marker()
 _conflict_file_re = re.compile(r"(.*)\.conflict-(.*)")
 
 

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -146,7 +146,7 @@ class RemoteSnapshotCacheService(service.Service):
         )
         self._cached_snapshots[snapshot_cap] = snapshot
         Message.log(message_type="remote-cache:cached",
-                    relpath=snapshot.metadata['name'],
+                    relpath=snapshot.metadata["relpath"],
                     capability=snapshot.capability)
 
         # breadth-first traversal of the parents

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -298,7 +298,7 @@ class MagicFolderUpdater(object):
                           capability=snapshot.capability,
                           ) as action:
             # if we're already conflicted, no further processing
-            if self._config.list_conflicts_for(snapshot.name):
+            if self._config.list_conflicts_for(relpath):
                 action.add_success_fields(is_conflict=True)
                 return
 
@@ -412,7 +412,7 @@ class MagicFolderUpdater(object):
             # filesystem.
             if is_conflict:
                 self._magic_fs.mark_conflict(relpath, conflict_path, staged)
-                self._config.add_conflict(snapshot.name, snapshot.author.name)
+                self._config.add_conflict(relpath, snapshot.author.name)
 
             else:
                 # there is a longer dance described in detail in

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -297,8 +297,6 @@ class MagicFolderUpdater(object):
                           relpath=relpath,
                           capability=snapshot.capability,
                           ) as action:
-            relpath = magic2path(snapshot.name)
-
             # if we're already conflicted, no further processing
             if self._config.list_conflicts_for(snapshot.name):
                 action.add_success_fields(is_conflict=True)

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -412,7 +412,7 @@ class MagicFolderUpdater(object):
             # filesystem.
             if is_conflict:
                 self._magic_fs.mark_conflict(relpath, conflict_path, staged)
-                self._config.add_conflict(relpath, snapshot.author.name)
+                self._config.add_conflict(snapshot)
 
             else:
                 # there is a longer dance described in detail in
@@ -425,7 +425,7 @@ class MagicFolderUpdater(object):
                     # The file changed since we started processing this item
                     action.add_success_fields(conflict_reason="last-minute-change")
                     self._magic_fs.mark_conflict(relpath, conflict_path, staged)
-                    self._config.add_conflict(snapshot.name, snapshot.author.name)
+                    self._config.add_conflict(snapshot)
                 else:
                     try:
                         path_state = self._magic_fs.mark_overwrite(relpath, snapshot.metadata["modification_time"], staged)

--- a/src/magic_folder/status.py
+++ b/src/magic_folder/status.py
@@ -267,7 +267,10 @@ class WebSocketStatusService(service.Service):
                     "relpath": relpath,
                     "modified": timestamp,
                     "last-updated": last_updated,
-                    "conflicts": mf_config.list_conflicts_for(relpath),
+                    "conflicts": [
+                        conflict.author_name
+                        for conflict in mf_config.list_conflicts_for(relpath)
+                    ],
                 }
                 for relpath, timestamp, last_updated
                 in self._config.get_magic_folder(name).get_recent_remotesnapshot_paths(30)

--- a/src/magic_folder/status.py
+++ b/src/magic_folder/status.py
@@ -29,7 +29,7 @@ from twisted.application import (
     service,
 )
 
-from .magicpath import(
+from .magicpath import (
     path2magic,
 )
 from .util.file import (

--- a/src/magic_folder/status.py
+++ b/src/magic_folder/status.py
@@ -29,9 +29,6 @@ from twisted.application import (
     service,
 )
 
-from .magicpath import (
-    path2magic,
-)
 from .util.file import (
     seconds_to_ns,
     ns_to_seconds,
@@ -270,7 +267,7 @@ class WebSocketStatusService(service.Service):
                     "relpath": relpath,
                     "modified": timestamp,
                     "last-updated": last_updated,
-                    "conflicts": mf_config.list_conflicts_for(path2magic(relpath)),
+                    "conflicts": mf_config.list_conflicts_for(relpath),
                 }
                 for relpath, timestamp, last_updated
                 in self._config.get_magic_folder(name).get_recent_remotesnapshot_paths(30)

--- a/src/magic_folder/status.py
+++ b/src/magic_folder/status.py
@@ -267,10 +267,7 @@ class WebSocketStatusService(service.Service):
                     "relpath": relpath,
                     "modified": timestamp,
                     "last-updated": last_updated,
-                    "conflicts": [
-                        conflict.author_name
-                        for conflict in mf_config.list_conflicts_for(relpath)
-                    ],
+                    "conflicted": bool(len(mf_config.list_conflicts_for(relpath))),
                 }
                 for relpath, timestamp, last_updated
                 in self._config.get_magic_folder(name).get_recent_remotesnapshot_paths(30)

--- a/src/magic_folder/status.py
+++ b/src/magic_folder/status.py
@@ -29,6 +29,9 @@ from twisted.application import (
     service,
 )
 
+from .magicpath import(
+    path2magic,
+)
 from .util.file import (
     seconds_to_ns,
     ns_to_seconds,
@@ -261,11 +264,13 @@ class WebSocketStatusService(service.Service):
         )
 
         def folder_data_for(name):
+            mf_config = self._config.get_magic_folder(name)
             most_recent = [
                 {
                     "relpath": relpath,
                     "modified": timestamp,
                     "last-updated": last_updated,
+                    "conflicts": mf_config.list_conflicts_for(path2magic(relpath)),
                 }
                 for relpath, timestamp, last_updated
                 in self._config.get_magic_folder(name).get_recent_remotesnapshot_paths(30)

--- a/src/magic_folder/test/fixtures.py
+++ b/src/magic_folder/test/fixtures.py
@@ -202,6 +202,7 @@ class RemoteSnapshotCreatorFixture(Fixture):
 
 @attr.s
 class MagicFolderNode(object):
+    # FIXME docstring
     tahoe_root = attr.ib()
     http_client = attr.ib(validator=attr.validators.instance_of(HTTPClient))
     global_service = attr.ib(validator=attr.validators.instance_of(MagicFolderService))

--- a/src/magic_folder/test/strategies.py
+++ b/src/magic_folder/test/strategies.py
@@ -405,9 +405,10 @@ def remote_snapshots(relpaths=path_segments(), authors=remote_authors()):
     """
     return builds(
         RemoteSnapshot,
+        relpath=relpaths,
         author=authors,
         metadata=fixed_dictionaries({
-            "name": relpaths,
+            "relpath": relpaths,
             "modification_time": integers(min_value=0, max_value=2**32),
         }),
         capability=tahoe_lafs_immutable_dir_capabilities(),

--- a/src/magic_folder/test/test_api_cli.py
+++ b/src/magic_folder/test/test_api_cli.py
@@ -569,6 +569,7 @@ class TestDumpState(AsyncTestCase):
         config.store_downloaded_snapshot(
             "bar",
             RemoteSnapshot(
+                "bar",
                 author,
                 {"modification_time": 0},
                 capability="URI:DIR2-CHK:l7b3rn6pha6c2ipbbo4yxvunvy:c6ppejrkip4cdfo3kmyju36qbb6bbptzhh3pno7jb5b5myzoxkja:1:5:329",

--- a/src/magic_folder/test/test_config.py
+++ b/src/magic_folder/test/test_config.py
@@ -926,7 +926,7 @@ class ConflictTests(SyncTestCase):
         self.assertThat(
             self.db.list_conflicts(),
             Equals({
-                "foo": Conflict("URI:DIR2-CHK:", [self.author.name]),
+                "foo": [Conflict("URI:DIR2-CHK:", self.author.name)],
             }),
         )
 
@@ -956,7 +956,7 @@ class ConflictTests(SyncTestCase):
             "foo",
             create_local_author(u"desktop"),
             {"relpath": "foo", "modification_time": 1234},
-            "URI:DIR2-CHK:",
+            "URI:DIR2-CHK:aaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             [],
             "URI:DIR2-CHK:",
         )
@@ -964,7 +964,7 @@ class ConflictTests(SyncTestCase):
             "foo",
             create_local_author(u"laptop"),
             {"relpath": "foo", "modification_time": 1234},
-            "URI:DIR2-CHK:",
+            "URI:DIR2-CHK:bbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             [],
             "URI:DIR2-CHK:",
         )
@@ -974,7 +974,10 @@ class ConflictTests(SyncTestCase):
         self.assertThat(
             self.db.list_conflicts(),
             Equals({
-                "foo": Conflict("URI:DIR2-CHK:", ["desktop", "laptop"]),
+                "foo": [
+                    Conflict("URI:DIR2-CHK:aaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "desktop"),
+                    Conflict("URI:DIR2-CHK:bbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "laptop"),
+                ],
             })
         )
 
@@ -1005,7 +1008,10 @@ class ConflictTests(SyncTestCase):
         self.assertThat(
             self.db.list_conflicts(),
             Equals({
-                "foo": Conflict("URI:DIR2-CHK:", ["laptop", "phone"]),
+                "foo": [
+                    Conflict("URI:DIR2-CHK:", "laptop"),
+                    Conflict("URI:DIR2-CHK:", "phone"),
+                ]
             }),
         )
 

--- a/src/magic_folder/test/test_config.py
+++ b/src/magic_folder/test/test_config.py
@@ -643,19 +643,18 @@ class MagicFolderConfigCurrentSnapshotTests(SyncTestCase):
         )
 
     @given(
-        relative_paths(),
         remote_snapshots(),
         path_states(),
     )
-    def test_remotesnapshot_roundtrips(self, relpath, snapshot, path_state):
+    def test_remotesnapshot_roundtrips(self, snapshot, path_state):
         """
         The capability for a ``RemoteSnapshot`` added with
         ``MagicFolderConfig.store_downloaded_snapshot`` can be read back with
         ``MagicFolderConfig.get_remotesnapshot``.
         """
-        self.db.store_downloaded_snapshot(relpath, snapshot, path_state)
-        capability = self.db.get_remotesnapshot(relpath)
-        db_path_state = self.db.get_currentsnapshot_pathstate(relpath)
+        self.db.store_downloaded_snapshot(snapshot.relpath, snapshot, path_state)
+        capability = self.db.get_remotesnapshot(snapshot.relpath)
+        db_path_state = self.db.get_currentsnapshot_pathstate(snapshot.relpath)
         self.assertThat(
             (capability, db_path_state),
             Equals((snapshot.capability, path_state))
@@ -855,8 +854,9 @@ class RemoteSnapshotTimeTests(SyncTestCase):
         for x in range(35):
             relpath = "foo_{}".format(x)
             remote = RemoteSnapshot(
+                relpath,
                 self.author,
-                {"name": relpath, "modification_time": x},
+                {"relpath": relpath, "modification_time": x},
                 "URI:DIR2-CHK:",
                 [],
                 "URI:DIR2-CHK:",

--- a/src/magic_folder/test/test_config.py
+++ b/src/magic_folder/test/test_config.py
@@ -898,8 +898,10 @@ class ConflictTests(SyncTestCase):
 
         self.db.add_conflict("foo", "laptop")
         self.assertThat(
-            self.db.list_conflicts("foo"),
-            Equals(["laptop"]),
+            self.db.list_conflicts(),
+            Equals({
+                "foo": ["laptop"],
+            }),
         )
 
     def test_add_list_multi_conflict(self):
@@ -910,8 +912,10 @@ class ConflictTests(SyncTestCase):
         self.db.add_conflict("foo", "laptop")
         self.db.add_conflict("foo", "phone")
         self.assertThat(
-            set(self.db.list_conflicts("foo")),
-            Equals({"laptop", "phone"}),
+            self.db.list_conflicts(),
+            Equals({
+                "foo": ["laptop", "phone"]
+            })
         )
 
     def test_delete_multi_conflict(self):
@@ -922,12 +926,14 @@ class ConflictTests(SyncTestCase):
         self.db.add_conflict("foo", "laptop")
         self.db.add_conflict("foo", "phone")
         self.assertThat(
-            set(self.db.list_conflicts("foo")),
-            Equals({"laptop", "phone"}),
+            self.db.list_conflicts(),
+            Equals({
+                "foo": ["laptop", "phone"],
+            }),
         )
 
         self.db.resolve_conflict("foo")
         self.assertThat(
-            self.db.list_conflicts("foo"),
-            Equals(None),
+            self.db.list_conflicts(),
+            Equals(dict()),
         )

--- a/src/magic_folder/test/test_config.py
+++ b/src/magic_folder/test/test_config.py
@@ -907,12 +907,20 @@ class ConflictTests(SyncTestCase):
         """
         Adding a conflict allows us to list it
         """
+        snap = RemoteSnapshot(
+            "foo",
+            self.author,
+            {"relpath": "foo", "modification_time": 1234},
+            "URI:DIR2-CHK:",
+            [],
+            "URI:DIR2-CHK:",
+        )
 
-        self.db.add_conflict("foo", "laptop")
+        self.db.add_conflict(snap)
         self.assertThat(
             self.db.list_conflicts(),
             Equals({
-                "foo": ["laptop"],
+                "foo": [self.author.name],
             }),
         )
 
@@ -921,12 +929,29 @@ class ConflictTests(SyncTestCase):
         A multiple-conflict is reflected in the list
         """
 
-        self.db.add_conflict("foo", "laptop")
-        self.db.add_conflict("foo", "phone")
+        snap0 = RemoteSnapshot(
+            "foo",
+            create_local_author(u"desktop"),
+            {"relpath": "foo", "modification_time": 1234},
+            "URI:DIR2-CHK:",
+            [],
+            "URI:DIR2-CHK:",
+        )
+        snap1 = RemoteSnapshot(
+            "foo",
+            create_local_author(u"laptop"),
+            {"relpath": "foo", "modification_time": 1234},
+            "URI:DIR2-CHK:",
+            [],
+            "URI:DIR2-CHK:",
+        )
+
+        self.db.add_conflict(snap0)
+        self.db.add_conflict(snap1)
         self.assertThat(
             self.db.list_conflicts(),
             Equals({
-                "foo": ["laptop", "phone"]
+                "foo": ["desktop", "laptop"]
             })
         )
 
@@ -935,8 +960,25 @@ class ConflictTests(SyncTestCase):
         A multiple-conflict is successfully deleted
         """
 
-        self.db.add_conflict("foo", "laptop")
-        self.db.add_conflict("foo", "phone")
+        snap0 = RemoteSnapshot(
+            "foo",
+            create_local_author(u"laptop"),
+            {"relpath": "foo", "modification_time": 1234},
+            "URI:DIR2-CHK:",
+            [],
+            "URI:DIR2-CHK:",
+        )
+        snap1 = RemoteSnapshot(
+            "foo",
+            create_local_author(u"phone"),
+            {"relpath": "foo", "modification_time": 1234},
+            "URI:DIR2-CHK:",
+            [],
+            "URI:DIR2-CHK:",
+        )
+
+        self.db.add_conflict(snap0)
+        self.db.add_conflict(snap1)
         self.assertThat(
             self.db.list_conflicts(),
             Equals({

--- a/src/magic_folder/test/test_config.py
+++ b/src/magic_folder/test/test_config.py
@@ -69,6 +69,7 @@ from .strategies import (
     local_snapshots,
     folder_names,
     path_states,
+    author_names,
 )
 from ..common import APIError, InvalidMagicFolderName, NoSuchMagicFolder
 from ..config import (
@@ -947,4 +948,21 @@ class ConflictTests(SyncTestCase):
         self.assertThat(
             self.db.list_conflicts(),
             Equals(dict()),
+        )
+
+    @given(
+        relative_paths(),
+        author_names(),
+    )
+    def test_conflict_file(self, relpath, author):
+        """
+        A conflict-file is detected as one.
+        """
+        conflict_path = self.db.magic_path.preauthChild(
+            "{}.conflict-{}".format(relpath, author)
+        )
+
+        self.assertThat(
+            self.db.is_conflict_marker(conflict_path),
+            Equals(True)
         )

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -1096,6 +1096,10 @@ class ConflictTests(AsyncTestCase):
             self.updater,
             tahoe_client,
         )
+        # it's hard to know _precisely_ when the loop will declare the
+        # error and take the timestamp; maybe makes sense to not
+        # compare the timestamp in the marshal'd state?
+        now = int(self.status._clock.seconds())
         yield top_service._loop()
 
         # status system should report our error
@@ -1105,8 +1109,9 @@ class ConflictTests(AsyncTestCase):
                 "state": ContainsDict({
                     "folders": ContainsDict({
                         "default": ContainsDict({
-                            "errors": ContainsDict([
+                            "errors": Equals([
                                 {
+                                    "timestamp": now,
                                     "summary": "Failed to overwrite file 'foo': [Errno 13] Permission denied",
                                 },
                             ]),

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -1306,12 +1306,14 @@ class ConflictTests(AsyncTestCase):
                 "state": ContainsDict({
                     "folders": ContainsDict({
                         "default": ContainsDict({
-                            "errors": Equals([
-                                {
-                                    "timestamp": int(self.status._clock.seconds()),
-                                    "summary": "Failed to download snapshot for 'foo'.",
-                                },
-                            ]),
+                            "errors": AfterPreprocessing(
+                                lambda errors: errors[0],
+                                ContainsDict({
+                                    "summary": Equals(
+                                        "Failed to download snapshot for 'foo'."
+                                    )
+                                }),
+                            ),
                         }),
                     }),
                 }),

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -1105,9 +1105,8 @@ class ConflictTests(AsyncTestCase):
                 "state": ContainsDict({
                     "folders": ContainsDict({
                         "default": ContainsDict({
-                            "errors": Equals([
+                            "errors": ContainsDict([
                                 {
-                                    "timestamp": int(self.status._clock.seconds()),
                                     "summary": "Failed to overwrite file 'foo': [Errno 13] Permission denied",
                                 },
                             ]),

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -164,7 +164,7 @@ class CacheTests(SyncTestCase):
         relpath = "foo"
         metadata = {
             "snapshot_version": 1,
-            "name": relpath,
+            "relpath": relpath,
             "author": self.author.to_remote_author().to_json(),
             "parents": [],
         }
@@ -221,7 +221,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": Equals([]),
-                        "name": Equals(relpath),
+                        "relpath": Equals(relpath),
                     }),
                 )
             )
@@ -239,7 +239,7 @@ class CacheTests(SyncTestCase):
         for who in range(5):
             metadata = {
                 "snapshot_version": 1,
-                "name": relpath,
+                "relpath": relpath,
                 "author": self.author.to_remote_author().to_json(),
                 "parents": parents,
             }
@@ -301,7 +301,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": Equals([]),
-                        "name": Equals(relpath),
+                        "relpath": Equals(relpath),
                     }),
                 )
             )
@@ -321,7 +321,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": AfterPreprocessing(len, Equals(1)),
-                        "name": Equals(relpath),
+                        "relpath": Equals(relpath),
                     }),
                 )
             )
@@ -343,7 +343,7 @@ class CacheTests(SyncTestCase):
                     metadata=ContainsDict({
                         "snapshot_version": Equals(1),
                         "parents": AfterPreprocessing(len, Equals(1)),
-                        "name": Equals(relpath),
+                        "relpath": Equals(relpath),
                     }),
                 )
             )
@@ -809,6 +809,7 @@ class ConflictTests(AsyncTestCase):
 
         cap0 = b"URI:DIR2-CHK:aaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1:5:376"
         remote0 = RemoteSnapshot(
+            relpath="foo",
             author=self.carol,
             metadata={"modification_time": 0},
             capability=cap0,
@@ -855,6 +856,7 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:bbbbbbbbbbbbbbbbbbbbbbbbbb:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:1:5:376"
         parent = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,
@@ -870,6 +872,7 @@ class ConflictTests(AsyncTestCase):
 
         cap0 = b"URI:DIR2-CHK:aaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1:5:376"
         remote0 = RemoteSnapshot(
+            relpath="foo",
             author=self.carol,
             metadata={"modification_time": 0},
             capability=cap0,
@@ -905,6 +908,7 @@ class ConflictTests(AsyncTestCase):
         for letter in 'abcd':
             parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format(letter * 26, letter * 52)
             parent = RemoteSnapshot(
+                relpath="foo",
                 author=self.alice,
                 metadata={"modification_time": 0},
                 capability=parent_cap,
@@ -941,6 +945,7 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,
@@ -951,6 +956,7 @@ class ConflictTests(AsyncTestCase):
 
         child_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('b' * 26, 'b' * 52)
         child = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=child_cap,
@@ -961,6 +967,7 @@ class ConflictTests(AsyncTestCase):
 
         other_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('z' * 26, 'z' * 52)
         other = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=other_cap,
@@ -995,8 +1002,9 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
-            metadata={"modification_time": 0},
+            metadata={"relpath": "foo", "modification_time": 0},
             capability=parent_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
@@ -1005,8 +1013,9 @@ class ConflictTests(AsyncTestCase):
 
         child_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('b' * 26, 'b' * 52)
         child = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
-            metadata={"modification_time": 0},
+            metadata={"relpath": "foo", "modification_time": 0},
             capability=child_cap,
             parents_raw=[parent_cap],
             content_cap=b"URI:CHK:",
@@ -1036,8 +1045,9 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
-            metadata={"modification_time": 0},
+            metadata={"relpath": "foo", "modification_time": 0},
             capability=parent_cap,
             parents_raw=[],
             content_cap=b"URI:CHK:",
@@ -1122,6 +1132,7 @@ class ConflictTests(AsyncTestCase):
 
         parent_cap = b"URI:DIR2-CHK:{}:{}:1:5:376".format('a' * 26, 'a' * 52)
         parent = RemoteSnapshot(
+            relpath="foo",
             author=self.alice,
             metadata={"modification_time": 0},
             capability=parent_cap,

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -471,8 +471,13 @@ class UpdateTests(AsyncTestCase):
                 if self.magic_path.child("foo").getContent() == content:
                     break
             yield deferLater(reactor, 1.0, lambda: None)
-        assert self.magic_path.child("foo").exists()
-        assert self.magic_path.child("foo").getContent() == content, "content mismatch"
+        self.assertThat(
+            self.magic_path.child("foo"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(content)),
+            )
+        )
 
     @inlineCallbacks
     def test_conflict(self):
@@ -510,8 +515,20 @@ class UpdateTests(AsyncTestCase):
             yield deferLater(reactor, 1.0, lambda: None)
 
         # we should conflict
-        assert self.magic_path.child("foo.conflict-zara").getContent() == content
-        assert self.magic_path.child("foo").getContent() == original_content
+        self.assertThat(
+            self.magic_path.child("foo.conflict-zara"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(content)),
+            )
+        )
+        self.assertThat(
+            self.magic_path.child("foo"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(original_content)),
+            )
+        )
 
     @inlineCallbacks
     def test_update(self):
@@ -562,8 +579,13 @@ class UpdateTests(AsyncTestCase):
                 if self.magic_path.child("foo").getContent() == content1:
                     break
             yield deferLater(reactor, 1.0, lambda: None)
-        assert self.magic_path.child("foo").exists()
-        assert self.magic_path.child("foo").getContent() == content1, "content mismatch"
+        self.assertThat(
+            self.magic_path.child("foo"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(content1)),
+            )
+        )
         self.assertThat(
             self.config.get_currentsnapshot_pathstate("foo"),
             MatchesAll(
@@ -714,8 +736,13 @@ class UpdateTests(AsyncTestCase):
             if "foo.conflict-zara" in self.magic_path.listdir():
                 break
             yield deferLater(reactor, 1.0, lambda: None)
-        assert self.magic_path.child("foo").exists()
-        assert self.magic_path.child("foo").getContent() == content2, "content mismatch"
+        self.assertThat(
+            self.magic_path.child("foo"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(content2)),
+            )
+        )
 
         # now we produce another update on Zara's side, which
         # shouldn't change anything locally because we're already
@@ -742,9 +769,13 @@ class UpdateTests(AsyncTestCase):
                 if self.magic_path.child("foo.conflict-zara").getContent() != content1:
                     print("weird content")
             yield deferLater(reactor, 1.0, lambda: None)
-        assert self.magic_path.child("foo").exists()
-        assert self.magic_path.child("foo").getContent() == content2, "content mismatch"
-
+        self.assertThat(
+            self.magic_path.child("foo"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(content2)),
+            )
+        )
 
 
 class ConflictTests(AsyncTestCase):

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -624,8 +624,13 @@ class UpdateTests(AsyncTestCase):
                 if self.magic_path.child("foo").getContent() == content1:
                     break
             yield deferLater(reactor, 1.0, lambda: None)
-        assert self.magic_path.child("foo").exists()
-        assert self.magic_path.child("foo").getContent() == content1, "content mismatch"
+        self.assertThat(
+            self.magic_path.child("foo"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(content1)),
+            )
+        )
 
         # create a second update
         local_snap2 = yield create_snapshot(
@@ -650,8 +655,13 @@ class UpdateTests(AsyncTestCase):
                 if self.magic_path.child("foo").getContent() == content2:
                     break
             yield deferLater(reactor, 1.0, lambda: None)
-        assert self.magic_path.child("foo").exists()
-        assert self.magic_path.child("foo").getContent() == content2, "content mismatch"
+        self.assertThat(
+            self.magic_path.child("foo"),
+            MatchesAll(
+                AfterPreprocessing(lambda x: x.exists(), Equals(True)),
+                AfterPreprocessing(lambda x: x.getContent(), Equals(content2)),
+            )
+        )
 
     @inlineCallbacks
     def test_conflicting_update(self):

--- a/src/magic_folder/test/test_local_snapshot.py
+++ b/src/magic_folder/test/test_local_snapshot.py
@@ -257,6 +257,26 @@ class LocalSnapshotServiceTests(SyncTestCase):
             ),
         )
 
+    def test_conflict_marker(self):
+        """
+        A conflict-marker file is not uploaded
+        """
+        self.setup_example()  # no @given() on this test
+        foo = self.magic_path.child("foo.conflict-laptop")
+        foo.setContent("bogus")
+
+        self.assertThat(
+            self.snapshot_service.add_file(foo),
+            succeeded(Always()),
+        )
+
+        # we should ignore this add_file() update and not upload /
+        # process it
+        self.assertThat(
+            self.snapshot_creator.processed,
+            Equals([]),
+        )
+
 
 class LocalSnapshotCreatorTests(SyncTestCase):
     """

--- a/src/magic_folder/test/test_scanner.py
+++ b/src/magic_folder/test/test_scanner.py
@@ -126,6 +126,7 @@ class FindUpdatesTests(SyncTestCase):
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
         snap = RemoteSnapshot(
+            relpath,
             self.author,
             metadata={
                 "modification_time": int(
@@ -160,6 +161,7 @@ class FindUpdatesTests(SyncTestCase):
         local.parent().asBytesMode("utf-8").makedirs(ignoreExistingDirectory=True)
         local.asBytesMode("utf-8").setContent(b"dummy\n")
         snap = RemoteSnapshot(
+            relpath,
             self.author,
             metadata={
                 # this remote is 2min older than our local file

--- a/src/magic_folder/test/test_snapshot.py
+++ b/src/magic_folder/test/test_snapshot.py
@@ -343,7 +343,7 @@ class TestRemoteSnapshot(SyncTestCase):
             downloaded_snapshot,
             MatchesStructure(
                 metadata=ContainsDict({
-                    "name": Equals(filename),
+                    "relpath": Equals(filename),
                     "modification_time": Equals(modified_time),
                 }),
             ),
@@ -477,7 +477,7 @@ class TestRemoteSnapshot(SyncTestCase):
         self.assertThat(
             snapshots[3],
             MatchesStructure(
-                metadata=ContainsDict({"name": Equals(filename)}),
+                metadata=ContainsDict({"relpath": Equals(filename)}),
                 parents_raw=Equals([snapshots[1].capability]),
             )
         )
@@ -525,7 +525,7 @@ class TestRemoteSnapshot(SyncTestCase):
         self.assertThat(
             remote_snapshot,
             MatchesStructure(
-                metadata=ContainsDict({"name": Equals(filename)}),
+                metadata=ContainsDict({"relpath": Equals(filename)}),
                 parents_raw=AfterPreprocessing(len, Equals(1)),
             )
         )
@@ -537,7 +537,7 @@ class TestRemoteSnapshot(SyncTestCase):
         self.assertThat(
             parent_snapshot,
             MatchesStructure(
-                metadata=ContainsDict({"name": Equals(filename)}),
+                metadata=ContainsDict({"relpath": Equals(filename)}),
                 parents_raw=Equals([]),
             )
         )

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -122,6 +122,10 @@ from ..client import (
     authorized_request,
     url_to_bytes,
 )
+from ..snapshot import (
+    RemoteSnapshot,
+    create_local_author,
+)
 from .strategies import (
     tahoe_lafs_readonly_dir_capabilities,
     tahoe_lafs_dir_capabilities,
@@ -2058,9 +2062,18 @@ class ConflictStatusTests(SyncTestCase):
             Equals(None)
         )
 
+        snap = RemoteSnapshot(
+            "foo",
+            create_local_author("nelli"),
+            {"relpath": "foo", "modification_time": 1234},
+            "URI:DIR2-CHK:",
+            [],
+            "URI:DIR2-CHK:",
+        )
+
         # adding it twice should still result in a single conflict
-        mf_config.add_conflict("foo", "nelli")
-        mf_config.add_conflict("foo", "nelli")
+        mf_config.add_conflict(snap)
+        mf_config.add_conflict(snap)
 
         # internal API
         self.assertThat(

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -258,6 +258,7 @@ class AuthorizationTests(SyncTestCase):
             ),
         )
 
+
 def treq_for_folders(
     reactor, basedir, auth_token, folders, start_folder_services, tahoe_client=None
 ):

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -2079,7 +2079,7 @@ class ConflictStatusTests(SyncTestCase):
         # internal API
         self.assertThat(
             mf_config.list_conflicts_for("foo"),
-            Equals(Conflict("URI:DIR2-CHK:", ["nelli"]))
+            Equals([Conflict("URI:DIR2-CHK:", "nelli")])
         )
 
         # external API

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -110,6 +110,9 @@ from .strategies import (
     author_names,
 )
 
+from ..config import (
+    Conflict,
+)
 from ..web import (
     magic_folder_resource,
     APIv1,
@@ -2071,14 +2074,12 @@ class ConflictStatusTests(SyncTestCase):
             "URI:DIR2-CHK:",
         )
 
-        # adding it twice should still result in a single conflict
-        mf_config.add_conflict(snap)
         mf_config.add_conflict(snap)
 
         # internal API
         self.assertThat(
             mf_config.list_conflicts_for("foo"),
-            Equals(["nelli"])
+            Equals(Conflict("URI:DIR2-CHK:", ["nelli"]))
         )
 
         # external API

--- a/src/magic_folder/test/test_web.py
+++ b/src/magic_folder/test/test_web.py
@@ -2062,7 +2062,7 @@ class ConflictStatusTests(SyncTestCase):
         # internal API for "no conflict yet"
         self.assertThat(
             mf_config.list_conflicts_for("foo"),
-            Equals(None)
+            Equals([])
         )
 
         snap = RemoteSnapshot(

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -225,14 +225,16 @@ class LocalSnapshotService(service.Service):
                 "argument must be a FilePath"
             )
 
-        if self._config.list_conflicts_for(path2magic(relpath)):
-            return
-
         # XXX also check if "path" _is_ a conflict-file
 
         try:
             # check that "path" is a descendant of magic_path
             relpath = u"/".join(path.segmentsFrom(self._config.magic_path))
+
+            # if this is already conflicted do no further work.
+            if self._config.list_conflicts_for(path2magic(relpath)):
+                return
+
             self._status.upload_queued(relpath)
         except ValueError:
             ADD_FILE_FAILURE.log(relpath=path.path) #FIXME relpath

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -226,8 +226,9 @@ class LocalSnapshotService(service.Service):
                 "argument must be a FilePath"
             )
 
-        # XXX check if "path" _is_ a conflict-file in which case it
-        # should not be uploaded
+        # if "path" _is_ a conflict-file it should not be uploaded
+        if self._config.is_conflict_marker(path):
+            return
 
         try:
             # check that "path" is a descendant of magic_path

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -226,14 +226,13 @@ class LocalSnapshotService(service.Service):
                 "argument must be a FilePath"
             )
 
-        # if "path" _is_ a conflict-file it should not be uploaded
-        if self._config.is_conflict_marker(path):
-            return
-
         try:
-            # check that "path" is a descendant of magic_path
-            relpath = u"/".join(path.segmentsFrom(self._config.magic_path))
+            # if "path" _is_ a conflict-file it should not be uploaded
+            # (this will throw ValueError if path is outside the magic-path)
+            if self._config.is_conflict_marker(path):
+                return
 
+            relpath = u"/".join(path.segmentsFrom(self._config.magic_path))
             self._status.upload_queued(relpath)
         except ValueError:
             ADD_FILE_FAILURE.log(relpath=path.path) #FIXME relpath

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -228,7 +228,9 @@ class LocalSnapshotService(service.Service):
 
         try:
             # if "path" _is_ a conflict-file it should not be uploaded
-            # (this will throw ValueError if path is outside the magic-path)
+            # This check (or the following "segmentsFrom") will throw
+            # ValueError if path is outside the magic-path .. this is
+            # desired as a check
             if self._config.is_conflict_marker(path):
                 return
 

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -225,6 +225,11 @@ class LocalSnapshotService(service.Service):
                 "argument must be a FilePath"
             )
 
+        if self._config.list_conflicts_for(path2magic(relpath)):
+            return
+
+        # XXX also check if "path" _is_ a conflict-file
+
         try:
             # check that "path" is a descendant of magic_path
             relpath = u"/".join(path.segmentsFrom(self._config.magic_path))

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -225,15 +225,12 @@ class LocalSnapshotService(service.Service):
                 "argument must be a FilePath"
             )
 
-        # XXX also check if "path" _is_ a conflict-file
+        # XXX check if "path" _is_ a conflict-file in which case it
+        # should not be uploaded
 
         try:
             # check that "path" is a descendant of magic_path
             relpath = u"/".join(path.segmentsFrom(self._config.magic_path))
-
-            # if this is already conflicted do no further work.
-            if self._config.list_conflicts_for(path2magic(relpath)):
-                return
 
             self._status.upload_queued(relpath)
         except ValueError:

--- a/src/magic_folder/uploader.py
+++ b/src/magic_folder/uploader.py
@@ -230,7 +230,7 @@ class LocalSnapshotService(service.Service):
             # if "path" _is_ a conflict-file it should not be uploaded
             # This check (or the following "segmentsFrom") will throw
             # ValueError if path is outside the magic-path .. this is
-            # desired as a check
+            # desired as a check as well
             if self._config.is_conflict_marker(path):
                 return
 

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -439,7 +439,10 @@ class APIv1(object):
         _application_json(request)  # set reply headers
         folder_config = self._global_config.get_magic_folder(folder_name)
 
-        return json.dumps(folder_config.list_conflicts())
+        return json.dumps({
+            relpath: conflict.author_names
+            for relpath, conflict in folder_config.list_conflicts().items()
+        })
 
 
 class _InputError(APIError):

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -468,6 +468,16 @@ class APIv1(object):
             in folder_config.get_all_current_snapshot_pathstates()
         ])
 
+    @app.route("/magic-folder/<string:folder_name>/conflicts", methods=['GET'])
+    def folder_file_status(self, request, folder_name):
+        """
+        Render status information for every file in a given folder
+        """
+        _application_json(request)  # set reply headers
+        folder_config = self._global_config.get_magic_folder(folder_name)
+
+        return json.dumps(folder_config.list_conflicts())
+
 
 class _InputError(APIError):
     """

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -440,8 +440,11 @@ class APIv1(object):
         folder_config = self._global_config.get_magic_folder(folder_name)
 
         return json.dumps({
-            relpath: conflict.author_names
-            for relpath, conflict in folder_config.list_conflicts().items()
+            relpath: [
+                conflict.author_name
+                for conflict in conflicts
+            ]
+            for relpath, conflicts in folder_config.list_conflicts().items()
         })
 
 

--- a/src/magic_folder/web.py
+++ b/src/magic_folder/web.py
@@ -469,7 +469,7 @@ class APIv1(object):
         ])
 
     @app.route("/magic-folder/<string:folder_name>/conflicts", methods=['GET'])
-    def folder_file_status(self, request, folder_name):
+    def list_conflicts(self, request, folder_name):
         """
         Render status information for every file in a given folder
         """


### PR DESCRIPTION
Fixes #538

Add a "conflicts" table, uses it in the downloader and includes some information about conflicts in the status API and via a `.../conflicts` API.