### PR TITLE
Detect un-scanned local changes as a conflict when downloading.

### DIFF
--- a/integration/test_synchronize.py
+++ b/integration/test_synchronize.py
@@ -475,3 +475,71 @@ def test_recover_twice(request, reactor, temp_filepath, alice, bob, edmond, take
         content1,
         timeout=25,
     )
+
+@pytest.mark.parametrize("take_snapshot", [add_snapshot, scan_folder])
+@pytest_twisted.inlineCallbacks
+def test_unscanned_conflict(request, reactor, temp_filepath, alice, bob, take_snapshot):
+    """
+    If we make a change to a local file and a change to the same file on a
+    peer, it is detected as a conflict, even if before we take a local snapshot
+    of it.
+    """
+    original_folder = temp_filepath.child("cats")
+    recover_folder = temp_filepath.child("kitties")
+    original_folder.makedirs()
+    recover_folder.makedirs()
+
+    # add our magic-folder and re-start
+    yield alice.add("original", original_folder.path)
+    alice_folders = yield alice.list_(True)
+
+    def cleanup_original():
+        # Maybe start the service, so we can remove the folder.
+        pytest_twisted.blockon(alice.start_magic_folder())
+        pytest_twisted.blockon(alice.leave("original"))
+    request.addfinalizer(cleanup_original)
+
+    # put a file in our folder
+    content0 = non_lit_content("zero")
+    original_folder.child("sylvester").setContent(content0)
+    yield take_snapshot(alice, "original", "sylvester")
+
+    # create the 'recovery' magic-folder
+    yield bob.add("recovery", recover_folder.path)
+
+    def cleanup_recovery():
+        # Maybe start the service, so we can remove the folder.
+        pytest_twisted.blockon(bob.start_magic_folder())
+        pytest_twisted.blockon(bob.leave("recovery"))
+    request.addfinalizer(cleanup_recovery)
+
+    # add the 'original' magic-folder as a participant in the
+    # 'recovery' folder
+    alice_cap = to_readonly_capability(alice_folders["original"]["upload_dircap"])
+    yield bob.add_participant("recovery", "alice", alice_cap)
+
+    # we should now see the only Snapshot we have in the folder appear
+    # in the 'recovery' filesystem
+    yield await_file_contents(
+        recover_folder.child("sylvester").path,
+        content0,
+        timeout=10,
+    )
+
+    content1 = non_lit_content("one")
+    recover_folder.child("sylvester").setContent(content1)
+
+    content2 = non_lit_content("two")
+    original_folder.child("sylvester").setContent(content2)
+    yield take_snapshot(alice, "original", "sylvester")
+
+    yield await_file_contents(
+        recover_folder.child("sylvester.conflict-alice").path,
+        content2,
+        timeout=25,
+    )
+    yield await_file_contents(
+        recover_folder.child("sylvester").path,
+        content1,
+        timeout=10,
+    )

--- a/integration/test_synchronize.py
+++ b/integration/test_synchronize.py
@@ -536,7 +536,68 @@ def test_unscanned_conflict(request, reactor, temp_filepath, alice, bob, take_sn
     yield await_file_contents(
         recover_folder.child("sylvester.conflict-alice").path,
         content2,
-        timeout=25,
+        timeout=10,
+    )
+    yield await_file_contents(
+        recover_folder.child("sylvester").path,
+        content1,
+        timeout=10,
+    )
+
+@pytest.mark.parametrize("take_snapshot", [add_snapshot, scan_folder])
+@pytest_twisted.inlineCallbacks
+def test_unscanned_vs_old(request, reactor, temp_filepath, alice, bob, take_snapshot):
+    """
+    If we make a change to a local file, it is not detected as a conflict.
+    """
+    original_folder = temp_filepath.child("cats")
+    recover_folder = temp_filepath.child("kitties")
+    original_folder.makedirs()
+    recover_folder.makedirs()
+
+    # add our magic-folder and re-start
+    yield alice.add("original", original_folder.path)
+    alice_folders = yield alice.list_(True)
+
+    def cleanup_original():
+        # Maybe start the service, so we can remove the folder.
+        pytest_twisted.blockon(alice.start_magic_folder())
+        pytest_twisted.blockon(alice.leave("original"))
+    request.addfinalizer(cleanup_original)
+
+    # put a file in our folder
+    content0 = non_lit_content("zero")
+    original_folder.child("sylvester").setContent(content0)
+    yield take_snapshot(alice, "original", "sylvester")
+
+    # create the 'recovery' magic-folder
+    yield bob.add("recovery", recover_folder.path)
+
+    def cleanup_recovery():
+        # Maybe start the service, so we can remove the folder.
+        pytest_twisted.blockon(bob.start_magic_folder())
+        pytest_twisted.blockon(bob.leave("recovery"))
+    request.addfinalizer(cleanup_recovery)
+
+    # add the 'original' magic-folder as a participant in the
+    # 'recovery' folder
+    alice_cap = to_readonly_capability(alice_folders["original"]["upload_dircap"])
+    yield bob.add_participant("recovery", "alice", alice_cap)
+
+    # we should now see the only Snapshot we have in the folder appear
+    # in the 'recovery' filesystem
+    yield await_file_contents(
+        recover_folder.child("sylvester").path,
+        content0,
+        timeout=10,
+    )
+
+    content1 = non_lit_content("one")
+    recover_folder.child("sylvester").setContent(content1)
+
+    yield ensure_file_not_created(
+        recover_folder.child("sylvester.conflict-alice").path,
+        timeout=10,
     )
     yield await_file_contents(
         recover_folder.child("sylvester").path,

--- a/src/magic_folder/downloader.py
+++ b/src/magic_folder/downloader.py
@@ -300,8 +300,15 @@ class MagicFolderUpdater(object):
                           ) as action:
             local_path = self._config.magic_path.preauthChild(relpath)
 
+            # TODO: We should be able to get all this info from a single
+            # database request
             # see if we have existing local or remote snapshots for
             # this relpath already
+            try:
+                current_pathstate = self._config.get_currentsnapshot_pathstate(relpath)
+            except KeyError:
+                current_pathstate = None
+
             try:
                 remote_cap = self._config.get_remotesnapshot(relpath)
                 # w/ no KeyError we have seen this before
@@ -317,6 +324,10 @@ class MagicFolderUpdater(object):
             except KeyError:
                 local_snap = None
 
+            assert current_pathstate is None or (
+                local_snap is not None or remote_cap is not None
+            ), "current_snapshots table is inconsistent"
+
             # note: if local_snap and remote_cap are both non-None
             # then remote_cap should already be the ancestor of
             # local_snap by definition.
@@ -326,18 +337,28 @@ class MagicFolderUpdater(object):
             # XXX not dealing with deletes yet
 
             is_conflict = False
-            local_timestamp = None
-            if local_path.exists():
-                local_timestamp = local_path.getModificationTime()
-                # there is a file here already .. if we have any
-                # LocalSnapshots for this relpath, then we've got local
-                # edits and it must be a conflict. If we have nothing
-                # in our remotesnapshot database then we've just not
-                # made a LocalSnapshot yet (so it's still a conflict).
-                if local_snap is not None or remote_cap is None:
+            local_pathinfo = get_pathinfo(local_path)
+            if local_pathinfo.exists:
+                # We have a conflict if:
+                # - the currently recorded snapshot is remote and is neither an
+                #   ancestor (update) or descendant (no-op) of the remote
+                #   snapshot we are evaluating.
+                if (
+                    # the file exists locally and we haven't recorded a
+                    # pathstate corresponding to snapshot of it
+                    current_pathstate is None
+                    # the pathstate on disk does not match the pathstate of the
+                    # currently recorded snapshot
+                    or current_pathstate != local_pathinfo.state
+                    # the currently recorded snapshot is local
+                    or local_snap is not None
+                    # we've never recorded a remote snapshot (so the local file
+                    # must have an unrelated history to the remote snapshot we
+                    # are considering)
+                    or remote_cap is None
+                ):
                     is_conflict = True
                     action.add_success_fields(conflict_reason="existing-file-no-remote")
-
                 else:
                     assert remote_cap != snapshot.capability, "already match"
 
@@ -359,7 +380,7 @@ class MagicFolderUpdater(object):
             else:
                 # there is no local file
                 # XXX we don't handle deletes yet
-                assert not local_snap and not remote_cap, "Internal inconsistency: record of a Snapshot for this relpath but no local file"
+                assert current_pathstate is None, "Internal inconsistency: record of a Snapshot for this relpath but no local file"
                 is_conflict = False
 
             action.add_success_fields(is_conflict=is_conflict)
@@ -397,15 +418,8 @@ class MagicFolderUpdater(object):
                 # local changes to get overwritten. Currently, that
                 # window is the 3 python statements between here and
                 # ".mark_overwrite()"
-                last_minute_change = False
-                if local_timestamp is None:
-                    if local_path.exists():
-                        last_minute_change = True
-                else:
-                    local_path.changed()
-                    if local_path.getModificationTime() != local_timestamp:
-                        last_minute_change = True
-                if last_minute_change:
+                if local_pathinfo != get_pathinfo(local_path):
+                    # The file changed since we started processing this item
                     action.add_success_fields(conflict_reason="last-minute-change")
                     self._magic_fs.mark_conflict(relpath, conflict_path, staged)
                     # FIXME note conflict internally

--- a/src/magic_folder/test/test_download.py
+++ b/src/magic_folder/test/test_download.py
@@ -742,8 +742,10 @@ class ConflictTests(AsyncTestCase):
             raw_remote_parents=None,
         )
         # if we have a local, we must have the path locally
-        self.alice_magic_path.child("foo").setContent(local0_content)
+        local_path = self.alice_magic_path.child("foo")
+        local_path.setContent(local0_content)
         self.alice_config.store_local_snapshot(local0)
+        self.alice_config.store_currentsnapshot_state("foo", get_pathinfo(local_path).state)
 
         # tell the updater to examine the remote-snapshot
         yield self.updater.add_remote_snapshot("foo", remote0)
@@ -776,9 +778,10 @@ class ConflictTests(AsyncTestCase):
         )
         parent_content = b"parent" * 1000
         self.remote_cache._cached_snapshots[parent_cap] = parent
-        self.alice_config.store_downloaded_snapshot("foo", parent, PathState(
-            mtime_ns=0, ctime_ns=0, size=len(parent_content),
-        ))
+        # we've 'seen' this file before so we must have the path locally
+        local_path = self.alice_magic_path.child("foo")
+        local_path.setContent(parent_content)
+        self.alice_config.store_downloaded_snapshot("foo", parent, get_pathinfo(local_path).state)
 
         cap0 = b"URI:DIR2-CHK:aaaaaaaaaaaaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1:5:376"
         remote0 = RemoteSnapshot(
@@ -790,8 +793,6 @@ class ConflictTests(AsyncTestCase):
         )
         self.remote_cache._cached_snapshots[cap0] = remote0
 
-        # we've 'seen' this file before so we must have the path locally
-        self.alice_magic_path.child("foo").setContent(parent_content)
 
         # tell the updater to examine the remote-snapshot
         yield self.updater.add_remote_snapshot("foo", remote0)
@@ -829,12 +830,10 @@ class ConflictTests(AsyncTestCase):
             remotes.append(parent)
 
         # set "our" parent to the oldest one
-        self.alice_config.store_downloaded_snapshot("foo", remotes[0], PathState(
-            mtime_ns=0, ctime_ns=0, size=len("dummy"),
-        ))
-
+        local_path = self.alice_magic_path.child("foo")
         # we've 'seen' this file before so we must have the path locally
-        self.alice_magic_path.child("foo").setContent(b"dummy")
+        local_path.setContent(b"dummy")
+        self.alice_config.store_downloaded_snapshot("foo", remotes[0], get_pathinfo(local_path).state)
 
         # tell the updater to examine the youngest remote
         youngest = remotes[-1]
@@ -930,10 +929,9 @@ class ConflictTests(AsyncTestCase):
         self.remote_cache._cached_snapshots[child_cap] = child
 
         # so "alice" has "child" already
-        self.alice_magic_path.child("foo").setContent("whatever")
-        self.alice_config.store_downloaded_snapshot("foo", child, PathState(
-            mtime_ns=0, ctime_ns=0, size=len("whatever"),
-        ))
+        local_path = self.alice_magic_path.child("foo")
+        local_path.setContent("whatever")
+        self.alice_config.store_downloaded_snapshot("foo", child, get_pathinfo(local_path).state)
 
         # we update with the parent (so, it's old)
         yield self.updater.add_remote_snapshot("foo", parent)


### PR DESCRIPTION
Fixes #455.

Use the recorded pathstate of our current snapshot to compare against the local file, to detect conflicts. This will allow us to detect if the local file has changed, and not yet been scanned.