### PR TITLE
Add a service that calls a function periodically or on-demand.

### DIFF
--- a/src/magic_folder/test/test_util_twisted.py
+++ b/src/magic_folder/test/test_util_twisted.py
@@ -1,0 +1,201 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import attr
+from eliot import log_call, start_action
+from eliot.testing import UnflushedTracebacks
+from hypothesis import settings
+from hypothesis.errors import StopTest
+from hypothesis.stateful import (RuleBasedStateMachine, initialize, invariant,
+                                 precondition, rule, run_state_machine_as_test)
+from hypothesis.strategies import booleans, data
+from testtools.matchers import HasLength, MatchesPredicate
+from twisted.internet.defer import Deferred
+from twisted.internet.task import Clock
+
+from ..util.twisted import PeriodicService
+from .common import SyncTestCase
+
+
+class FailedCall(Exception):
+    """
+    Exception used to indicate a failed call to the given
+    function in :py:`PeriodicService` state based tests.
+    """
+
+
+@attr.s(eq=False)
+class PeriodicServiceRuleMachine(RuleBasedStateMachine):
+    """
+    State machine to exercise a :py:`PeriodicService`.
+
+    :ivar SyncTestCase case: Test case the machine is running in.
+    :ivar Clock clock: Source of time for the service.
+    :ivar PeriodicService service: The service being tested.
+    :ivar List[Deferred[None]] current_calls:
+        List of outstanding deferreds from calls to the function.
+    :ivar bool should_call_soon: Whether there has been an explicit
+        request to call the function that has not yet happened.
+    """
+
+    case = attr.ib()
+    clock = attr.ib(init=False, factory=Clock)
+    service = attr.ib(init=False)
+    current_calls = attr.ib(init=False, factory=list)
+    should_call_soon = attr.ib(init=False, default=False)
+    failed_calls = attr.ib(init=False, default=0)
+
+    @log_call(include_result=False)
+    def f(self):
+        """
+        The function called by the service.
+
+        If there has been a request to call the function, we mark that request
+        as complete.
+
+        This either returns a deferred that is recorded in the list of
+        current calls, or a deferred that has already fired.
+        """
+        self.should_call_soon = False
+        d = Deferred()
+        self.current_calls.append(d)
+        # These self.data.draw calls can raise `StopTest`, which the service
+        # will catch and log. We flush them in `teardown`.
+        if self.data.draw(booleans(), "in f, should return fired deferred"):
+            if self.data.draw(booleans(), "in f, should return failure"):
+                self.fail()
+            else:
+                self.result()
+        return d
+
+    @service.default
+    def _create_service(self):
+        return PeriodicService(self.clock, self.f, 1)
+
+    def __attrs_post_init__(self):
+        super(PeriodicServiceRuleMachine, self).__init__()
+        self._action = start_action(action_type="machine")
+        # We use __enter__ and __exit__ explicitly here so that
+        # since there is no scope to use `with` to delimit a
+        # run of the state machine.
+        self._action.__enter__()
+
+    @initialize(data=data())
+    def init_data(self, data):
+        """
+        Store the result of hypothesis' ``data`` strategy, so
+        we can make choices in ``f``.
+        """
+        self.data = data
+
+    @invariant()
+    def one_call(self):
+        """
+        There is only zero or one calls to the function.
+        """
+        self.case.assertThat(
+            self.current_calls,
+            MatchesPredicate(
+                lambda l: len(l) <= 1, "There is more than one concurrent call."
+            ),
+        )
+
+    @precondition(lambda self: self.current_calls)
+    @rule()
+    @log_call
+    def result(self):
+        """
+        If there is an running call to the function,
+        finish the call.
+        """
+        self.current_calls.pop(0).callback(None)
+
+    @precondition(lambda self: self.current_calls)
+    @rule()
+    @log_call
+    def fail(self):
+        """
+        If there is an running call to the function,
+        finish the call with an exception.
+        """
+        self.current_calls.pop(0).errback(FailedCall())
+        self.failed_calls += 1
+
+    @rule()
+    @log_call
+    def start(self):
+        """
+        Start the service.
+        """
+        self.service.startService()
+
+    @rule()
+    @log_call
+    def stop(self):
+        """
+        Stop the service.
+        """
+        self.service.stopService()
+
+    @rule()
+    @log_call
+    def call(self):
+        """
+        Request a call to the function.
+        """
+        self.should_call_soon = True
+        self.service.call_soon()
+
+    @precondition(lambda self: self.should_call_soon)
+    @invariant()
+    def no_delay(self):
+        """
+        If there is a request to call the function,
+        we should never schedule a delay to call it.
+        """
+        assert len(self.clock.getDelayedCalls()) == 0
+
+    @precondition(lambda self: self.clock.getDelayedCalls())
+    @rule()
+    @log_call
+    def advance(self):
+        """
+        If there are any delayed calls, advance the clock.
+        """
+        self.clock.advance(1)
+
+    def teardown(self):
+        self._action.__exit__(None, None, None)
+        # These can be caused by the self.data.draw calls in given function.
+        # We can ignore them.
+        self.case.eliot_logger.flush_tracebacks(StopTest)
+        # Ensure that each failure of the given function was logged.
+        self.case.assertThat(
+            self.case.eliot_logger.flush_tracebacks(FailedCall),
+            HasLength(self.failed_calls),
+        )
+        # If we have any other logged tracebacks, that is unexpected and
+        # should cause this run to fail.
+        unflushed_tracebacks = self.case.eliot_logger.flushTracebacks(BaseException)
+        if unflushed_tracebacks:
+            raise UnflushedTracebacks(unflushed_tracebacks)
+
+
+class PeriodicSerivceTests(SyncTestCase):
+    def test_state_space(self):
+        """
+        Explore the state space of L{PeriodicService}
+        """
+        # One example is not enough to exercise the state machine.
+        if settings.default.max_examples == 1:
+            # We are running with the magic-folder-fast profile
+            # so use a relatively small number of examples.
+            state_settings = settings(max_examples=100)
+        else:
+            # We are running with the magic-folder-ci profile
+            # so we can use a large number of examples.
+            state_settings = settings(max_examples=1000)
+        run_state_machine_as_test(
+            lambda: PeriodicServiceRuleMachine(self),
+            settings=state_settings,
+        )

--- a/src/magic_folder/util/twisted.py
+++ b/src/magic_folder/util/twisted.py
@@ -5,14 +5,16 @@ Utilities for interacting with twisted.
 """
 
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from functools import wraps
+
+import attr
+from eliot import write_failure
+from twisted.application.service import Service
+from twisted.internet.defer import Deferred, maybeDeferred, succeed
+from twisted.internet.interfaces import IDelayedCall, IReactorTime
+from twisted.python.failure import Failure
 
 
 def exclusively(maybe_f=None, lock_name="_lock"):
@@ -22,6 +24,7 @@ def exclusively(maybe_f=None, lock_name="_lock"):
 
     :param str lock_name: The name of the lock attribute to use.
     """
+
     def wrap(f):
         @wraps(f)
         def wrapper(self, *args, **kwargs):
@@ -33,3 +36,130 @@ def exclusively(maybe_f=None, lock_name="_lock"):
         return wrap
     else:
         return wrap(maybe_f)
+
+
+@attr.s
+class PeriodicService(Service):
+    """
+    Service to periodically and on-demand call a given function.
+
+    When one or more requests to call the function arrive while the
+    function is running, the service will cause the function to be called
+    *once* immediately after the first call completes (though requests made
+    during the second call will cause an additional call). The assumption is
+    that new work for the function has arrived, but the function has likely
+    already determined what work it will do in the current call.
+
+    When a request to call the function arrives between periodic calls to
+    the function, the timer is reset.
+
+    Differences from :py:`twisted.application.internet.TimerService`:
+    - The interval represents time between when one call ends and the next one
+      starts, instead of between the interval between start times. This can
+      lead to the function being called at irregular intervals, if it takes
+      some time to run.
+
+      The motivation is that the periodic runs is to retry operations that have
+      failed. For example, if the function does enough work to overflow the
+      interval and then fails due to a loss of network connectivity, there is
+      no reason to try again immediately, instead of waiting.
+    - The service takes a clock explicitly, rather than having an attribute to
+      set to override the default reactor.
+    - The service logs and ignores exceptions from function, rather than stopping
+      periodic calls to the function.
+
+    :ivar IReactorTime _clock: Source of time
+    :ivar Callable[[], Deferred[None]] _callable:
+        Function to call. It will not be called again until the deferred it
+        retruns has fired.
+    :ivar int interval: The time between periodic calls to the function.
+    """
+    _clock = attr.ib(validator=attr.validators.provides(IReactorTime))
+    _callable = attr.ib(validator=attr.validators.is_callable())
+    _interval = attr.ib(validator=attr.validators.instance_of(int))
+
+    _delayed_call = attr.ib(
+        init=False,
+        default=None,
+        validator=attr.validators.optional(attr.validators.provides(IDelayedCall)),
+    )
+    _deferred = attr.ib(
+        init=False,
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(Deferred)),
+    )
+    _should_call = attr.ib(init=False, default=True)
+
+    def startService(self):
+        super(PeriodicService, self).startService()
+        self._schedule()
+
+    def stopService(self):
+        super(PeriodicService, self).stopService()
+        self._cancel_delayed_call()
+        if self._deferred is not None:
+            d = Deferred()
+            self._deferred.chainDeferred(d)
+            return d
+        else:
+            return succeed(None)
+
+    def call_soon(self):
+        """
+        Call the function soon.
+
+        This may be immediately, if we are waiting between calls. Or it may be
+        after the current call to the function is complete.
+        """
+        self._should_call = True
+        self._schedule()
+
+    def _cancel_delayed_call(self):
+        """
+        Cancel any pending delayed call, and remove our record of it.
+        """
+        if self._delayed_call is not None:
+            if self._delayed_call.active():
+                self._delayed_call.cancel()
+            self._delayed_call = None
+
+    def _call(self):
+        """
+        Call the given function, and arrange to schedule the
+        next call when it completes.
+        """
+        def cb(result):
+            self._deferred = None
+            if isinstance(result, Failure):
+                write_failure(result)
+            if self.running:
+                self._schedule()
+
+        # We've either been triggered by our delayed call (in which case we
+        # clear our record of it), or we've been explicitly requested to call
+        # the function (in which case we cancel it)
+        self._cancel_delayed_call()
+        self._deferred = maybeDeferred(self._callable)
+        self._deferred.addBoth(cb)
+
+    def _schedule(self):
+        """
+        Schedule a call to the given function.
+
+        - If the service isn't running, we don't do anything;
+          this method will be called again when the service is started.
+        - If the function is running, we don't do anything;
+          this method will be called again when the function is finished.
+        - If a call has been requested, start it now.
+        - Otherwise, if we haven't scheduled a future call, we scheduled it
+          the given interval into the future.
+        """
+        if not self.running:
+            return
+        if self._deferred is not None:
+            return
+        if self._should_call:
+            self._should_call = False
+            self._call()
+        elif self._delayed_call is None:
+            self._delayed_call = self._clock.callLater(self._interval, self._call)


### PR DESCRIPTION
Fixes #552. 

Use this to ensure that we don't have duplicate calls to `UploaderService.perform_upload`.