### PR TITLE
remove the GitHub Actions steps that prepare to build zfec

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,18 +25,6 @@ jobs:
     # Get tags not fetched by the checkout action, needed for auto-versioning.
     - run: "git fetch origin +refs/tags/*:refs/tags/*"
 
-    # Get MS VC++ 9 aka Visual Studio 2008, required to build Python 2.7
-    # extensions (zfec via Tahoe-LAFS).
-    - name: Build local chocloatey package for MSVC 9.0 for Python 2.7
-      uses: "crazy-max/ghaction-chocolatey@v1"
-      with:
-        args: "pack .github/vcpython27/vcpython27.nuspec"
-
-    - name: Install MSVC 9.0 for Python 2.7
-      uses: "crazy-max/ghaction-chocolatey@v1"
-      with:
-        args: "install --source=.;https://chocolatey.org/api/v2/ vcpython27"
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -98,18 +86,6 @@ jobs:
         fetch-depth: "0"
     # Get tags not fetched by the checkout action, needed for auto-versioning.
     - run: "git fetch origin +refs/tags/*:refs/tags/*"
-
-    # Get MS VC++ 9 aka Visual Studio 2008, required to build Python 2.7
-    # extensions (zfec via Tahoe-LAFS).
-    - name: Build local chocloatey package for MSVC 9.0 for Python 2.7
-      uses: "crazy-max/ghaction-chocolatey@v1"
-      with:
-        args: "pack .github/vcpython27/vcpython27.nuspec"
-
-    - name: Install MSVC 9.0 for Python 2.7
-      uses: "crazy-max/ghaction-chocolatey@v1"
-      with:
-        args: "install --source=.;https://chocolatey.org/api/v2/ vcpython27"
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1


### PR DESCRIPTION
Fixes #600 

zfec distributes binary wheels for many python versions on pypi

This saves perhaps 2 minutes per build, judging from some recent build logs.
